### PR TITLE
Update to latest. Ensure we report on ALL features in data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mdn/browser-compat-data": "5.3.24",
-    "caniuse-db": "1.0.30001550"
+    "@mdn/browser-compat-data": "5.5.14",
+    "caniuse-db": "1.0.30001594"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web-features-evergreen",
   "main": "index.js",
   "scripts": {
-    "update": "node main.js > readme.md"
+    "update": "node main.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -26,11 +26,11 @@
   - [`api.Navigator.wakeLock`](https://developer.mozilla.org/docs/Web/API/Navigator/wakeLock)
   - `api.SVGFESpecularLightingElement.kernelUnitLengthX`
   - `api.SVGFESpecularLightingElement.kernelUnitLengthY`
-  - [`api.WakeLock`](https://developer.mozilla.org/docs/Web/API/WakeLock) +1
-  - [`api.WakeLockSentinel`](https://developer.mozilla.org/docs/Web/API/WakeLockSentinel) +1 +1 +1 +1
+  - [`api.WakeLock`](https://developer.mozilla.org/docs/Web/API/WakeLock)
+  - [`api.WakeLockSentinel`](https://developer.mozilla.org/docs/Web/API/WakeLockSentinel)
   - [`css.properties.paint-order`](https://developer.mozilla.org/docs/Web/CSS/paint-order)
   - `css.properties.text-decoration-thickness.percentage`
-  - [`css.properties.text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) +1 +1
+  - [`css.properties.text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap)
   - `css.selectors.backdrop.inherit_from_originating_element`
   - [`http.headers.Permissions-Policy.screen-wake-lock`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/screen-wake-lock)
   - [`javascript.builtins.ArrayBuffer.detached`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached)
@@ -62,10 +62,10 @@
   - [`api.HTMLVideoElement.disablePictureInPicture`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/disablePictureInPicture)
   - `css.properties.offset-path.ray`
   - `css.properties.offset-path.url`
-  - [`css.properties.offset-position`](https://developer.mozilla.org/docs/Web/CSS/offset-position) +1 +1
+  - [`css.properties.offset-position`](https://developer.mozilla.org/docs/Web/CSS/offset-position)
   - [`css.types.basic-shape.rect`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/rect)
   - [`css.types.basic-shape.xywh`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/xywh)
-  - [`css.types.ray`](https://developer.mozilla.org/docs/Web/CSS/ray) +1 +1
+  - [`css.types.ray`](https://developer.mozilla.org/docs/Web/CSS/ray)
   - `html.elements.video.disablepictureinpicture`
   - [`javascript.builtins.Array.fromAsync`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync)
 
@@ -88,11 +88,11 @@
   - [`api.URL.canParse_static`](https://developer.mozilla.org/docs/Web/API/URL/canParse_static)
   - [`css.at-rules.media.scripting`](https://developer.mozilla.org/docs/Web/CSS/@media/scripting)
   - `css.properties.background-clip.text`
-  - [`css.properties.counter-set`](https://developer.mozilla.org/docs/Web/CSS/counter-set) +1 +1
+  - [`css.properties.counter-set`](https://developer.mozilla.org/docs/Web/CSS/counter-set)
   - [`css.properties.mask-clip`](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
-  - [`css.properties.mask-composite`](https://developer.mozilla.org/docs/Web/CSS/mask-composite) +1 +1 +1 +1
+  - [`css.properties.mask-composite`](https://developer.mozilla.org/docs/Web/CSS/mask-composite)
   - [`css.properties.mask-image`](https://developer.mozilla.org/docs/Web/CSS/mask-image)
-  - [`css.properties.mask-mode`](https://developer.mozilla.org/docs/Web/CSS/mask-mode) +1 +1 +1
+  - [`css.properties.mask-mode`](https://developer.mozilla.org/docs/Web/CSS/mask-mode)
   - [`css.properties.mask-origin`](https://developer.mozilla.org/docs/Web/CSS/mask-origin)
   - [`css.properties.mask-position`](https://developer.mozilla.org/docs/Web/CSS/mask-position)
   - [`css.properties.mask-repeat`](https://developer.mozilla.org/docs/Web/CSS/mask-repeat)
@@ -129,8 +129,8 @@
   - `api.BeforeUnloadEvent.returnValue`
   - [`api.Navigator.userActivation`](https://developer.mozilla.org/docs/Web/API/Navigator/userActivation)
   - `api.PublicKeyCredential.authenticatorAttachment`
-  - [`api.ToggleEvent`](https://developer.mozilla.org/docs/Web/API/ToggleEvent) +1 +1 +1
-  - [`api.UserActivation`](https://developer.mozilla.org/docs/Web/API/UserActivation) +1 +1
+  - [`api.ToggleEvent`](https://developer.mozilla.org/docs/Web/API/ToggleEvent)
+  - [`api.UserActivation`](https://developer.mozilla.org/docs/Web/API/UserActivation)
   - `css.properties.clip-path.fill-box`
   - `css.properties.clip-path.stroke-box`
   - [`css.selectors.user-invalid`](https://developer.mozilla.org/docs/Web/CSS/:user-invalid)
@@ -252,12 +252,12 @@
 ### These Features became stable across all major browsers:
   - [`api.CSSContainerRule.containerName`](https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerName)
   - [`api.CSSContainerRule.containerQuery`](https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerQuery)
-  - [`api.CSSCounterStyleRule`](https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.CSSCounterStyleRule`](https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule)
   - `api.CanvasRenderingContext2D.drawImage.SVGImageElement_source_image`
   - [`api.CredentialsContainer.preventSilentAccess`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)
   - [`api.CustomElementRegistry.getName`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/getName)
-  - [`api.DeviceMotionEvent`](https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent) +1 +1 +1 +1
-  - [`api.DeviceOrientationEvent`](https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent) +1 +1 +1
+  - [`api.DeviceMotionEvent`](https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent)
+  - [`api.DeviceOrientationEvent`](https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent)
   - [`api.Headers.getSetCookie`](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie)
   - [`api.Response.json_static`](https://developer.mozilla.org/docs/Web/API/Response/json_static)
   - [`api.Selection.removeRange`](https://developer.mozilla.org/docs/Web/API/Selection/removeRange)
@@ -265,18 +265,18 @@
   - [`api.URLSearchParams.size`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/size)
   - [`api.Window.devicemotion_event`](https://developer.mozilla.org/docs/Web/API/Window/devicemotion_event)
   - [`api.Window.deviceorientation_event`](https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event)
-  - [`css.at-rules.counter-style`](https://developer.mozilla.org/docs/Web/CSS/@counter-style) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.at-rules.counter-style`](https://developer.mozilla.org/docs/Web/CSS/@counter-style)
   - [`css.at-rules.font-face.size-adjust`](https://developer.mozilla.org/docs/Web/CSS/@font-face/size-adjust)
   - [`css.at-rules.media.overflow-block`](https://developer.mozilla.org/docs/Web/CSS/@media/overflow-block)
   - [`css.at-rules.media.overflow-inline`](https://developer.mozilla.org/docs/Web/CSS/@media/overflow-inline)
   - [`css.at-rules.media.update`](https://developer.mozilla.org/docs/Web/CSS/@media/update-frequency)
   - `css.at-rules.supports.font-format`
   - `css.at-rules.supports.font-tech`
-  - [`css.properties.contain-intrinsic-block-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size) +1
-  - [`css.properties.contain-intrinsic-height`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height) +1
-  - [`css.properties.contain-intrinsic-inline-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size) +1
-  - [`css.properties.contain-intrinsic-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size) +1 +1
-  - [`css.properties.contain-intrinsic-width`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width) +1
+  - [`css.properties.contain-intrinsic-block-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size)
+  - [`css.properties.contain-intrinsic-height`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height)
+  - [`css.properties.contain-intrinsic-inline-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size)
+  - [`css.properties.contain-intrinsic-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size)
+  - [`css.properties.contain-intrinsic-width`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width)
   - [`css.properties.font-variant-position`](https://developer.mozilla.org/docs/Web/CSS/font-variant-position)
   - [`css.properties.grid-template-columns.subgrid`](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
   - [`css.properties.grid-template-rows.subgrid`](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
@@ -287,7 +287,7 @@
   - [`javascript.builtins.RegExp.unicodeSets`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets)
   - `mathml.elements.mtd.columnspan`
   - `mathml.elements.mtd.rowspan`
-  - `webextensions.api.scripting.executeScript.InjectionResult` +1 +1
+  - `webextensions.api.scripting.executeScript.InjectionResult`
 
 ## Sep 2023
 ### Browsers released:
@@ -301,10 +301,10 @@
   - [`api.CSSStyleRule.deleteRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/deleteRule)
   - [`api.CSSStyleRule.insertRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/insertRule)
   - [`api.CanvasRenderingContext2D.getContextAttributes`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getContextAttributes)
-  - [`api.RTCEncodedAudioFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame) +1 +1 +1
-  - [`api.RTCEncodedVideoFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame) +1 +1 +1 +1
+  - [`api.RTCEncodedAudioFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame)
+  - [`api.RTCEncodedVideoFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame)
   - [`css.properties.math-style`](https://developer.mozilla.org/docs/Web/CSS/math-style)
-  - [`css.properties.offset-anchor`](https://developer.mozilla.org/docs/Web/CSS/offset-anchor) +1
+  - [`css.properties.offset-anchor`](https://developer.mozilla.org/docs/Web/CSS/offset-anchor)
   - `css.types.color.lab.mixed_type_parameters`
   - `css.types.color.lch.mixed_type_parameters`
   - `css.types.color.oklab.mixed_type_parameters`
@@ -370,14 +370,8 @@
   - {'browser':'edge','version':'114'}
   - {'browser':'firefox','version':'114'}
 ### These Features became stable across all major browsers:
-  - [`api.CompressionStream`](https://developer.mozilla.org/docs/Web/API/CompressionStream) +1
-  - `api.CompressionStream.CompressionStream.deflate`
-  - `api.CompressionStream.CompressionStream.deflate-raw`
-  - `api.CompressionStream.CompressionStream.gzip` +1 +1
-  - [`api.DecompressionStream`](https://developer.mozilla.org/docs/Web/API/DecompressionStream) +1
-  - `api.DecompressionStream.DecompressionStream.deflate`
-  - `api.DecompressionStream.DecompressionStream.deflate-raw`
-  - `api.DecompressionStream.DecompressionStream.gzip` +1 +1
+  - [`api.CompressionStream`](https://developer.mozilla.org/docs/Web/API/CompressionStream)
+  - [`api.DecompressionStream`](https://developer.mozilla.org/docs/Web/API/DecompressionStream)
   - `api.HTMLInputElement.cancel_event`
   - [`api.RTCPeerConnection.connectionState`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/connectionState)
   - [`api.RTCPeerConnection.connectionstatechange_event`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/connectionstatechange_event)
@@ -385,14 +379,14 @@
   - [`api.RTCRtpReceiver.getCapabilities_static`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getCapabilities_static)
   - [`api.RTCRtpSender.getCapabilities_static`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getCapabilities_static)
   - [`api.RTCRtpSender.setStreams`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/setStreams)
-  - [`api.RTCSctpTransport`](https://developer.mozilla.org/docs/Web/API/RTCSctpTransport) +1 +1 +1 +1 +1
-  - [`api.RTCStatsReport.type_media-source`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_source) +1 +1 +1 +1 +1
-  - [`api.RTCStatsReport.type_peer-connection`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats) +1 +1 +1 +1 +1
+  - [`api.RTCSctpTransport`](https://developer.mozilla.org/docs/Web/API/RTCSctpTransport)
+  - [`api.RTCStatsReport.type_media-source`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_source)
+  - [`api.RTCStatsReport.type_peer-connection`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats)
   - [`css.properties.background-image.image-set`](https://developer.mozilla.org/docs/Web/CSS/image-set())
   - [`css.properties.content.gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient)
   - `css.selectors.nth-child.of_syntax`
   - `css.selectors.nth-last-child.of_syntax`
-  - [`css.types.color.color`](https://developer.mozilla.org/docs/Web/CSS/color_value/color) +1
+  - [`css.types.color.color`](https://developer.mozilla.org/docs/Web/CSS/color_value/color)
   - [`css.types.color.color-mix`](https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix)
   - [`css.types.color.lab`](https://developer.mozilla.org/docs/Web/CSS/color_value/lab)
   - [`css.types.color.lch`](https://developer.mozilla.org/docs/Web/CSS/color_value/lch)
@@ -403,15 +397,11 @@
   - [`webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_ENABLED_STATIC_RULESETS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_ENABLED_STATIC_RULESETS)
   - [`webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_STATIC_RULESETS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_STATIC_RULESETS)
   - [`webextensions.api.declarativeNetRequest.Redirect`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Redirect)
-  - [`webextensions.api.declarativeNetRequest.ResourceType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ResourceType) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`webextensions.api.declarativeNetRequest.ResourceType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ResourceType)
   - [`webextensions.api.declarativeNetRequest.Rule`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Rule)
-  - [`webextensions.api.declarativeNetRequest.RuleAction`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleAction) +1
-  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.header`
-  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.operation`
-  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.value`
-  - [`webextensions.api.declarativeNetRequest.RuleCondition`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition) +1 +1 +1
-  - [`webextensions.api.declarativeNetRequest.URLTransform`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/URLTransform) +1
-  - `webextensions.api.declarativeNetRequest.URLTransform.queryTransform.addOrReplaceParams` +1
+  - [`webextensions.api.declarativeNetRequest.RuleAction`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleAction)
+  - [`webextensions.api.declarativeNetRequest.RuleCondition`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition)
+  - [`webextensions.api.declarativeNetRequest.URLTransform`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/URLTransform)
   - [`webextensions.api.declarativeNetRequest.getDynamicRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getDynamicRules)
   - [`webextensions.api.declarativeNetRequest.getEnabledRulesets`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getEnabledRulesets)
   - [`webextensions.api.declarativeNetRequest.getSessionRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getSessionRules)
@@ -419,10 +409,7 @@
   - [`webextensions.api.declarativeNetRequest.updateDynamicRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateDynamicRules)
   - [`webextensions.api.declarativeNetRequest.updateEnabledRulesets`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateEnabledRulesets)
   - [`webextensions.api.declarativeNetRequest.updateSessionRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateSessionRules)
-  - [`webextensions.manifest.declarative_net_request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request) +1
-  - `webextensions.manifest.declarative_net_request.rule_resources.enabled`
-  - `webextensions.manifest.declarative_net_request.rule_resources.id`
-  - `webextensions.manifest.declarative_net_request.rule_resources.path`
+  - [`webextensions.manifest.declarative_net_request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request)
   - `webextensions.manifest.optional_permissions.declarativeNetRequestFeedback`
   - `webextensions.manifest.permissions.declarativeNetRequest`
   - `webextensions.manifest.permissions.declarativeNetRequestFeedback`
@@ -456,7 +443,7 @@
   - {'browser':'edge','version':'112'}
   - {'browser':'firefox','version':'112'}
 ### These Features became stable across all major browsers:
-  - [`api.CSSFontFeatureValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule) +1
+  - [`api.CSSFontFeatureValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule)
   - [`api.CSSStyleSheet.CSSStyleSheet`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
   - [`api.CSSStyleSheet.replace`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replace)
   - [`api.CSSStyleSheet.replaceSync`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync)
@@ -464,7 +451,7 @@
   - [`api.DedicatedWorkerGlobalScope.messageerror_event`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event)
   - [`api.DedicatedWorkerGlobalScope.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)
   - [`api.Document.adoptedStyleSheets`](https://developer.mozilla.org/docs/Web/API/Document/adoptedStyleSheets)
-  - [`api.Document.exitFullscreen`](https://developer.mozilla.org/docs/Web/API/Document/exitFullscreen) +1
+  - [`api.Document.exitFullscreen`](https://developer.mozilla.org/docs/Web/API/Document/exitFullscreen)
   - [`api.Document.fullscreen`](https://developer.mozilla.org/docs/Web/API/Document/fullscreen)
   - [`api.Document.fullscreenElement`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenElement)
   - [`api.Document.fullscreenEnabled`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenEnabled)
@@ -472,17 +459,13 @@
   - [`api.Document.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenerror_event)
   - [`api.Element.fullscreenchange_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenchange_event)
   - [`api.Element.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenerror_event)
-  - [`api.Element.requestFullscreen`](https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen) +1
-  - [`api.ElementInternals`](https://developer.mozilla.org/docs/Web/API/ElementInternals) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.FileSystemDirectoryHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle) +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.FileSystemFileHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle) +1 +1
-  - [`api.FileSystemHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemHandle) +1 +1 +1
-  - [`api.FileSystemSyncAccessHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle) +1
-  - `api.FileSystemSyncAccessHandle.close.sync_version` +1
-  - `api.FileSystemSyncAccessHandle.flush.sync_version` +1
-  - `api.FileSystemSyncAccessHandle.getSize.sync_version` +1 +1
-  - `api.FileSystemSyncAccessHandle.truncate.sync_version` +1
-  - [`api.GamepadHapticActuator`](https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator) +1
+  - [`api.Element.requestFullscreen`](https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen)
+  - [`api.ElementInternals`](https://developer.mozilla.org/docs/Web/API/ElementInternals)
+  - [`api.FileSystemDirectoryHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle)
+  - [`api.FileSystemFileHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle)
+  - [`api.FileSystemHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemHandle)
+  - [`api.FileSystemSyncAccessHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle)
+  - [`api.GamepadHapticActuator`](https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator)
   - [`api.HTMLCanvasElement.transferControlToOffscreen`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen)
   - [`api.HTMLElement.attachInternals`](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)
   - [`api.HTMLElement.translate`](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
@@ -492,27 +475,25 @@
   - [`api.InputEvent.isComposing`](https://developer.mozilla.org/docs/Web/API/InputEvent/isComposing)
   - [`api.MessagePort.messageerror_event`](https://developer.mozilla.org/docs/Web/API/MessagePort/messageerror_event)
   - [`api.Navigator.pdfViewerEnabled`](https://developer.mozilla.org/docs/Web/API/Navigator/pdfViewerEnabled)
-  - [`api.Notification`](https://developer.mozilla.org/docs/Web/API/Notification) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.NotificationEvent`](https://developer.mozilla.org/docs/Web/API/NotificationEvent) +1
-  - [`api.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas) +1 +1 +1
-  - `api.OffscreenCanvas.getContext.2d_context`
-  - `api.OffscreenCanvas.getContext.bitmaprenderer_context` +1 +1 +1
-  - [`api.OffscreenCanvasRenderingContext2D`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.Notification`](https://developer.mozilla.org/docs/Web/API/Notification)
+  - [`api.NotificationEvent`](https://developer.mozilla.org/docs/Web/API/NotificationEvent)
+  - [`api.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas)
+  - [`api.OffscreenCanvasRenderingContext2D`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D)
   - [`api.PerformanceResourceTiming.decodedBodySize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize)
   - [`api.PerformanceResourceTiming.encodedBodySize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize)
   - [`api.PerformanceResourceTiming.serverTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/serverTiming)
   - [`api.PerformanceResourceTiming.transferSize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize)
-  - [`api.PerformanceServerTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming) +1 +1 +1 +1
+  - [`api.PerformanceServerTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming)
   - [`api.PermissionStatus.change_event`](https://developer.mozilla.org/docs/Web/API/PermissionStatus/change_event)
-  - [`api.PushEvent`](https://developer.mozilla.org/docs/Web/API/PushEvent) +1 +1
-  - [`api.PushManager`](https://developer.mozilla.org/docs/Web/API/PushManager) +1 +1 +1
-  - [`api.PushMessageData`](https://developer.mozilla.org/docs/Web/API/PushMessageData) +1 +1 +1 +1
-  - [`api.PushSubscription`](https://developer.mozilla.org/docs/Web/API/PushSubscription) +1 +1 +1 +1 +1 +1
-  - [`api.PushSubscriptionOptions`](https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions) +1
+  - [`api.PushEvent`](https://developer.mozilla.org/docs/Web/API/PushEvent)
+  - [`api.PushManager`](https://developer.mozilla.org/docs/Web/API/PushManager)
+  - [`api.PushMessageData`](https://developer.mozilla.org/docs/Web/API/PushMessageData)
+  - [`api.PushSubscription`](https://developer.mozilla.org/docs/Web/API/PushSubscription)
+  - [`api.PushSubscriptionOptions`](https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions)
   - `api.RTCStatsReport.type_inbound-rtp.trackIdentifier`
   - [`api.SVGStyleElement.sheet`](https://developer.mozilla.org/docs/Web/API/SVGStyleElement/sheet)
   - [`api.Screen.orientation`](https://developer.mozilla.org/docs/Web/API/Screen/orientation)
-  - [`api.ScreenOrientation`](https://developer.mozilla.org/docs/Web/API/ScreenOrientation) +1 +1 +1
+  - [`api.ScreenOrientation`](https://developer.mozilla.org/docs/Web/API/ScreenOrientation)
   - [`api.ServiceWorkerContainer.messageerror_event`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/messageerror_event)
   - [`api.ServiceWorkerRegistration.getNotifications`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/getNotifications)
   - [`api.ServiceWorkerRegistration.pushManager`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/pushManager)
@@ -523,15 +504,15 @@
   - [`api.StorageManager.getDirectory`](https://developer.mozilla.org/docs/Web/API/StorageManager/getDirectory)
   - [`api.Window.messageerror_event`](https://developer.mozilla.org/docs/Web/API/Window/messageerror_event)
   - [`api.WritableStreamDefaultController.signal`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal)
-  - [`css.at-rules.font-feature-values`](https://developer.mozilla.org/docs/Web/CSS/@font-feature-values) +1 +1 +1 +1 +1 +1 +1
+  - [`css.at-rules.font-feature-values`](https://developer.mozilla.org/docs/Web/CSS/@font-feature-values)
   - [`css.at-rules.media.or_syntax`](https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#testing_for_multiple_features_with_or)
   - [`css.at-rules.media.range_syntax`](https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4)
   - `css.properties.font-size.xxx-large`
-  - [`css.properties.font-synthesis-small-caps`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps) +1 +1
-  - [`css.properties.font-synthesis-style`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style) +1 +1
-  - [`css.properties.font-synthesis-weight`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight) +1 +1
+  - [`css.properties.font-synthesis-small-caps`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps)
+  - [`css.properties.font-synthesis-style`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style)
+  - [`css.properties.font-synthesis-weight`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight)
   - `css.properties.font-variant.historical-forms`
-  - [`css.properties.font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates) +1 +1 +1 +1 +1 +1
+  - [`css.properties.font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates)
   - [`css.properties.outline`](https://developer.mozilla.org/docs/Web/CSS/outline)
   - `css.selectors.backdrop.fullscreen`
   - [`css.selectors.fullscreen`](https://developer.mozilla.org/docs/Web/CSS/:fullscreen)
@@ -553,7 +534,7 @@
   - [`javascript.operators.import_meta.resolve`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta/resolve)
   - [`javascript.regular_expressions.lookbehind_assertion`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion)
   - `webassembly.fixed-width-SIMD`
-  - [`webextensions.api.scripting.RegisteredContentScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript) +1
+  - [`webextensions.api.scripting.RegisteredContentScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript)
   - [`webextensions.api.scripting.getRegisteredContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/getRegisteredContentScripts)
   - [`webextensions.api.scripting.registerContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/registerContentScripts)
   - [`webextensions.api.scripting.unregisterContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/unregisterContentScripts)
@@ -576,8 +557,8 @@
   - [`css.at-rules.container`](https://developer.mozilla.org/docs/Web/CSS/@container)
   - [`css.at-rules.media.color-gamut`](https://developer.mozilla.org/docs/Web/CSS/@media/color-gamut)
   - [`css.properties.container`](https://developer.mozilla.org/docs/Web/CSS/container)
-  - [`css.properties.container-name`](https://developer.mozilla.org/docs/Web/CSS/container-name) +1
-  - [`css.properties.container-type`](https://developer.mozilla.org/docs/Web/CSS/container-type) +1 +1 +1
+  - [`css.properties.container-name`](https://developer.mozilla.org/docs/Web/CSS/container-name)
+  - [`css.properties.container-type`](https://developer.mozilla.org/docs/Web/CSS/container-type)
   - `css.properties.font-variant.sub`
   - `css.properties.font-variant.super`
   - [`css.selectors.autofill`](https://developer.mozilla.org/docs/Web/CSS/:autofill)
@@ -591,23 +572,23 @@
   - {'browser':'edge','version':'110'}
   - {'browser':'firefox','version':'110'}
 ### These Features became stable across all major browsers:
-  - [`api.MathMLElement`](https://developer.mozilla.org/docs/Web/API/MathMLElement) +1 +1 +1 +1 +1
+  - [`api.MathMLElement`](https://developer.mozilla.org/docs/Web/API/MathMLElement)
   - [`http.headers.Content-Security-Policy.unsafe-hashes`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#unsafe-hashes)
   - [`mathml.elements.maction`](https://developer.mozilla.org/docs/Web/MathML/Element/maction)
-  - [`mathml.elements.math`](https://developer.mozilla.org/docs/Web/MathML/Element/math) +1
+  - [`mathml.elements.math`](https://developer.mozilla.org/docs/Web/MathML/Element/math)
   - [`mathml.elements.merror`](https://developer.mozilla.org/docs/Web/MathML/Element/merror)
-  - [`mathml.elements.mfrac`](https://developer.mozilla.org/docs/Web/MathML/Element/mfrac) +1
-  - [`mathml.elements.mi`](https://developer.mozilla.org/docs/Web/MathML/Element/mi) +1
+  - [`mathml.elements.mfrac`](https://developer.mozilla.org/docs/Web/MathML/Element/mfrac)
+  - [`mathml.elements.mi`](https://developer.mozilla.org/docs/Web/MathML/Element/mi)
   - [`mathml.elements.mmultiscripts`](https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts)
   - [`mathml.elements.mn`](https://developer.mozilla.org/docs/Web/MathML/Element/mn)
-  - [`mathml.elements.mo`](https://developer.mozilla.org/docs/Web/MathML/Element/mo) +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`mathml.elements.mover`](https://developer.mozilla.org/docs/Web/MathML/Element/mover) +1
-  - [`mathml.elements.mpadded`](https://developer.mozilla.org/docs/Web/MathML/Element/mpadded) +1 +1 +1 +1 +1
+  - [`mathml.elements.mo`](https://developer.mozilla.org/docs/Web/MathML/Element/mo)
+  - [`mathml.elements.mover`](https://developer.mozilla.org/docs/Web/MathML/Element/mover)
+  - [`mathml.elements.mpadded`](https://developer.mozilla.org/docs/Web/MathML/Element/mpadded)
   - [`mathml.elements.mphantom`](https://developer.mozilla.org/docs/Web/MathML/Element/mphantom)
   - [`mathml.elements.mroot`](https://developer.mozilla.org/docs/Web/MathML/Element/mroot)
   - [`mathml.elements.mrow`](https://developer.mozilla.org/docs/Web/MathML/Element/mrow)
   - [`mathml.elements.ms`](https://developer.mozilla.org/docs/Web/MathML/Element/ms)
-  - [`mathml.elements.mspace`](https://developer.mozilla.org/docs/Web/MathML/Element/mspace) +1 +1 +1
+  - [`mathml.elements.mspace`](https://developer.mozilla.org/docs/Web/MathML/Element/mspace)
   - [`mathml.elements.msqrt`](https://developer.mozilla.org/docs/Web/MathML/Element/msqrt)
   - [`mathml.elements.mstyle`](https://developer.mozilla.org/docs/Web/MathML/Element/mstyle)
   - [`mathml.elements.msub`](https://developer.mozilla.org/docs/Web/MathML/Element/msub)
@@ -617,8 +598,8 @@
   - [`mathml.elements.mtd`](https://developer.mozilla.org/docs/Web/MathML/Element/mtd)
   - [`mathml.elements.mtext`](https://developer.mozilla.org/docs/Web/MathML/Element/mtext)
   - [`mathml.elements.mtr`](https://developer.mozilla.org/docs/Web/MathML/Element/mtr)
-  - [`mathml.elements.munder`](https://developer.mozilla.org/docs/Web/MathML/Element/munder) +1
-  - [`mathml.elements.munderover`](https://developer.mozilla.org/docs/Web/MathML/Element/munderover) +1 +1
+  - [`mathml.elements.munder`](https://developer.mozilla.org/docs/Web/MathML/Element/munder)
+  - [`mathml.elements.munderover`](https://developer.mozilla.org/docs/Web/MathML/Element/munderover)
   - [`mathml.elements.semantics`](https://developer.mozilla.org/docs/Web/MathML/Element/semantics)
   - [`mathml.global_attributes.dir`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir)
   - [`mathml.global_attributes.displaystyle`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle)
@@ -627,7 +608,7 @@
   - [`mathml.global_attributes.mathsize`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize)
   - `svg.global_attributes.requiredExtensions.mathml`
   - [`webextensions.api.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action)
-  - [`webextensions.manifest.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) +1 +1 +1
+  - [`webextensions.manifest.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action)
   - [`webextensions.manifest.host_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions)
   - `webextensions.manifest.manifest_version.v3`
   - [`webextensions.manifest.web_accessible_resources.matches`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#matches)
@@ -644,7 +625,7 @@
   - [`api.HTMLMediaElement.srcObject`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject)
   - [`api.HTMLSourceElement.height`](https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/height)
   - [`api.HTMLSourceElement.width`](https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/width)
-  - [`api.OES_draw_buffers_indexed`](https://developer.mozilla.org/docs/Web/API/OES_draw_buffers_indexed) +1 +1 +1 +1 +1 +1 +1
+  - [`api.OES_draw_buffers_indexed`](https://developer.mozilla.org/docs/Web/API/OES_draw_buffers_indexed)
   - `css.properties.align-items.flex_context.last_baseline`
   - `css.properties.align-self.flex_context.last_baseline`
   - [`css.types.calc-constant`](https://developer.mozilla.org/docs/Web/CSS/calc-constant)
@@ -673,9 +654,9 @@
   - {'browser':'safari','version':'16.2'}
   - {'browser':'safari_ios','version':'16.2'}
 ### These Features became stable across all major browsers:
-  - [`api.CSSFontPaletteValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule) +1 +1 +1 +1
-  - [`css.at-rules.font-palette-values`](https://developer.mozilla.org/docs/Web/CSS/@font-palette-values) +1 +1 +1
-  - [`css.properties.font-palette`](https://developer.mozilla.org/docs/Web/CSS/font-palette) +1 +1 +1
+  - [`api.CSSFontPaletteValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule)
+  - [`css.at-rules.font-palette-values`](https://developer.mozilla.org/docs/Web/CSS/@font-palette-values)
+  - [`css.properties.font-palette`](https://developer.mozilla.org/docs/Web/CSS/font-palette)
 
 ## Nov 2022
 ### Browsers released:
@@ -708,20 +689,20 @@
   - [`api.FetchEvent.handled`](https://developer.mozilla.org/docs/Web/API/FetchEvent/handled)
   - [`api.FetchEvent.resultingClientId`](https://developer.mozilla.org/docs/Web/API/FetchEvent/resultingClientId)
   - [`api.HTMLFormElement.requestSubmit`](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit)
-  - [`api.HTMLInputElement.showPicker`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker) +1
+  - [`api.HTMLInputElement.showPicker`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker)
   - [`api.HTMLScriptElement.supports_static`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/supports_static)
   - [`api.KeyframeEffect.composite`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite)
   - [`api.Navigator.permissions`](https://developer.mozilla.org/docs/Web/API/Navigator/permissions)
-  - [`api.PermissionStatus`](https://developer.mozilla.org/docs/Web/API/PermissionStatus) +1 +1
-  - [`api.Permissions`](https://developer.mozilla.org/docs/Web/API/Permissions) +1 +1
-  - [`api.SharedWorker`](https://developer.mozilla.org/docs/Web/API/SharedWorker) +1 +1 +1
-  - [`api.SharedWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope) +1 +1 +1
+  - [`api.PermissionStatus`](https://developer.mozilla.org/docs/Web/API/PermissionStatus)
+  - [`api.Permissions`](https://developer.mozilla.org/docs/Web/API/Permissions)
+  - [`api.SharedWorker`](https://developer.mozilla.org/docs/Web/API/SharedWorker)
+  - [`api.SharedWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope)
   - [`api.SpeechSynthesis.voiceschanged_event`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/voiceschanged_event)
   - [`api.SpeechSynthesisErrorEvent.SpeechSynthesisErrorEvent`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisErrorEvent/SpeechSynthesisErrorEvent)
   - [`api.SpeechSynthesisEvent.SpeechSynthesisEvent`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/SpeechSynthesisEvent)
   - [`api.SpeechSynthesisEvent.charLength`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/charLength)
-  - [`api.TextDecoderStream`](https://developer.mozilla.org/docs/Web/API/TextDecoderStream) +1 +1 +1 +1 +1 +1
-  - [`api.TextEncoderStream`](https://developer.mozilla.org/docs/Web/API/TextEncoderStream) +1 +1 +1 +1
+  - [`api.TextDecoderStream`](https://developer.mozilla.org/docs/Web/API/TextDecoderStream)
+  - [`api.TextEncoderStream`](https://developer.mozilla.org/docs/Web/API/TextEncoderStream)
   - [`api.WindowClient.navigate`](https://developer.mozilla.org/docs/Web/API/WindowClient/navigate)
   - [`api.WorkerGlobalScope.fonts`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/fonts)
   - `api.WorkerGlobalScope.importScripts.mime_checks`
@@ -734,19 +715,19 @@
   - [`css.properties.offset`](https://developer.mozilla.org/docs/Web/CSS/offset)
   - [`css.properties.offset-distance`](https://developer.mozilla.org/docs/Web/CSS/offset-distance)
   - `css.properties.offset-path.path`
-  - [`css.properties.offset-rotate`](https://developer.mozilla.org/docs/Web/CSS/offset-rotate) +1 +1
+  - [`css.properties.offset-rotate`](https://developer.mozilla.org/docs/Web/CSS/offset-rotate)
   - `css.properties.overflow.clip`
   - `css.properties.overflow-x.clip`
   - `css.properties.overflow-y.clip`
-  - [`css.properties.overscroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior) +1 +1 +1
-  - [`css.properties.overscroll-behavior-block`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block) +1 +1 +1
-  - [`css.properties.overscroll-behavior-inline`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline) +1 +1 +1
-  - [`css.properties.overscroll-behavior-x`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x) +1 +1 +1
-  - [`css.properties.overscroll-behavior-y`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y) +1
-  - [`css.properties.text-align-last`](https://developer.mozilla.org/docs/Web/CSS/text-align-last) +1
+  - [`css.properties.overscroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior)
+  - [`css.properties.overscroll-behavior-block`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block)
+  - [`css.properties.overscroll-behavior-inline`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline)
+  - [`css.properties.overscroll-behavior-x`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x)
+  - [`css.properties.overscroll-behavior-y`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y)
+  - [`css.properties.text-align-last`](https://developer.mozilla.org/docs/Web/CSS/text-align-last)
   - `css.properties.user-select.all`
   - [`css.selectors.modal`](https://developer.mozilla.org/docs/Web/CSS/:modal)
-  - [`css.types.basic-shape.path`](https://developer.mozilla.org/docs/Web/CSS/path) +1
+  - [`css.types.basic-shape.path`](https://developer.mozilla.org/docs/Web/CSS/path)
   - `css.types.overflow.clip`
   - `http.headers.Content-Security-Policy.script-src.wasm-unsafe-eval`
   - `webextensions.manifest.permissions.unlimitedStorage`
@@ -764,9 +745,9 @@
   - `api.RTCStatsReport.type_inbound-rtp.silentConcealedSamples`
   - `api.RTCStatsReport.type_inbound-rtp.totalSamplesReceived`
   - [`api.SVGStyleElement.disabled`](https://developer.mozilla.org/docs/Web/API/SVGStyleElement/disabled)
-  - [`css.properties.rotate`](https://developer.mozilla.org/docs/Web/CSS/rotate) +1 +1
-  - [`css.properties.scale`](https://developer.mozilla.org/docs/Web/CSS/scale) +1
-  - [`css.properties.translate`](https://developer.mozilla.org/docs/Web/CSS/translate) +1
+  - [`css.properties.rotate`](https://developer.mozilla.org/docs/Web/CSS/rotate)
+  - [`css.properties.scale`](https://developer.mozilla.org/docs/Web/CSS/scale)
+  - [`css.properties.translate`](https://developer.mozilla.org/docs/Web/CSS/translate)
   - [`javascript.builtins.Array.findLast`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast)
   - [`javascript.builtins.Array.findLastIndex`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex)
   - [`javascript.builtins.TypedArray.findLast`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast)
@@ -785,7 +766,7 @@
   - `css.properties.align-content.flex_context.start_end`
   - [`css.properties.backdrop-filter`](https://developer.mozilla.org/docs/Web/CSS/backdrop-filter)
   - [`css.properties.contain.style`](https://developer.mozilla.org/docs/Web/CSS/contain#style)
-  - [`css.properties.scroll-snap-stop`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop) +1 +1
+  - [`css.properties.scroll-snap-stop`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop)
 
 ## Jul 2022
 ### Browsers released:
@@ -794,11 +775,9 @@
   - {'browser':'safari_ios','version':'15.6'}
 ### These Features became stable across all major browsers:
   - [`api.ReadableStream.pipeThrough`](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough)
-  - [`api.TransformStream`](https://developer.mozilla.org/docs/Web/API/TransformStream) +1 +1 +1
-  - [`api.TransformStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController) +1 +1 +1 +1
-  - [`webextensions.api.scripting`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/) +1
-  - `webextensions.api.scripting.ExecutionWorld.ISOLATED` +1 +1
-  - `webextensions.api.scripting.executeScript.world` +1 +1
+  - [`api.TransformStream`](https://developer.mozilla.org/docs/Web/API/TransformStream)
+  - [`api.TransformStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController)
+  - [`webextensions.api.scripting`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/)
   - `webextensions.manifest.optional_permissions.scripting`
   - `webextensions.manifest.permissions.scripting`
 
@@ -819,15 +798,14 @@
   - `api.RTCStatsReport.type_outbound-rtp.retransmittedBytesSent`
   - `api.RTCStatsReport.type_outbound-rtp.retransmittedPacketsSent`
   - [`api.ReadableStream.pipeTo`](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo)
-  - [`api.WritableStream`](https://developer.mozilla.org/docs/Web/API/WritableStream) +1 +1 +1 +1 +1
-  - [`api.WritableStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController) +1
-  - [`api.WritableStreamDefaultWriter`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.WritableStream`](https://developer.mozilla.org/docs/Web/API/WritableStream)
+  - [`api.WritableStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController)
+  - [`api.WritableStreamDefaultWriter`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter)
   - [`css.at-rules.media.dynamic-range`](https://developer.mozilla.org/docs/Web/CSS/@media/dynamic-range)
   - [`css.at-rules.media.prefers-contrast`](https://developer.mozilla.org/docs/Web/CSS/@media/prefers-contrast)
   - [`http.headers.Content-Security-Policy.worker-src`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
-  - [`webassembly.api.Exception`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception) +1
-  - [`webassembly.api.Exception.Exception.options_parameter_traceStack`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/Exception) +1 +1
-  - [`webassembly.api.Tag`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag) +1
+  - [`webassembly.api.Exception`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception)
+  - [`webassembly.api.Tag`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag)
   - `webassembly.exception-handling`
   - [`webextensions.api.storage.StorageArea.onChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged)
 
@@ -841,7 +819,7 @@
 ### These Features became stable across all major browsers:
   - [`api.FetchEvent.preloadResponse`](https://developer.mozilla.org/docs/Web/API/FetchEvent/preloadResponse)
   - [`api.MediaCapabilities.encodingInfo`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo)
-  - [`api.NavigationPreloadManager`](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager) +1 +1 +1 +1
+  - [`api.NavigationPreloadManager`](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager)
   - [`api.RTCPeerConnection.setConfiguration`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setConfiguration)
   - [`api.ServiceWorkerRegistration.navigationPreload`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/navigationPreload)
   - `css.properties.mix-blend-mode.plus-lighter`
@@ -857,25 +835,25 @@
   - `api.AbortSignal.abort_static.reason_parameter`
   - [`api.AbortSignal.reason`](https://developer.mozilla.org/docs/Web/API/AbortSignal/reason)
   - [`api.AbortSignal.throwIfAborted`](https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted)
-  - [`api.BroadcastChannel`](https://developer.mozilla.org/docs/Web/API/BroadcastChannel) +1 +1 +1 +1 +1 +1
+  - [`api.BroadcastChannel`](https://developer.mozilla.org/docs/Web/API/BroadcastChannel)
   - [`api.CSSImportRule.layerName`](https://developer.mozilla.org/docs/Web/API/CSSImportRule/layerName)
-  - [`api.CSSLayerBlockRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule) +1
-  - [`api.CSSLayerStatementRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule) +1
+  - [`api.CSSLayerBlockRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule)
+  - [`api.CSSLayerStatementRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule)
   - [`api.Crypto.randomUUID`](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
   - [`api.Document.securitypolicyviolation_event`](https://developer.mozilla.org/docs/Web/API/Document/securitypolicyviolation_event)
-  - [`api.HTMLDialogElement`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement) +1 +1 +1 +1 +1 +1 +1
+  - [`api.HTMLDialogElement`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement)
   - [`api.HTMLElement.nonce`](https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce)
   - [`api.HTMLElement.outerText`](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
   - [`api.HTMLImageElement.loading`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/loading)
-  - [`api.Lock`](https://developer.mozilla.org/docs/Web/API/Lock) +1 +1
-  - [`api.LockManager`](https://developer.mozilla.org/docs/Web/API/LockManager) +1 +1
+  - [`api.Lock`](https://developer.mozilla.org/docs/Web/API/Lock)
+  - [`api.LockManager`](https://developer.mozilla.org/docs/Web/API/LockManager)
   - [`api.Navigator.locks`](https://developer.mozilla.org/docs/Web/API/Navigator/locks)
-  - [`api.RTCDtlsTransport`](https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport) +1 +1
+  - [`api.RTCDtlsTransport`](https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport)
   - [`api.RTCPeerConnection.canTrickleIceCandidates`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/canTrickleIceCandidates)
   - `api.RTCPeerConnection.setRemoteDescription.implicit_rollback`
   - [`api.RTCRtpReceiver.transport`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/transport)
   - [`api.RTCRtpSender.transport`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/transport)
-  - [`api.RTCStatsReport.type_codec`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#codec) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_codec`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#codec)
   - `api.RTCStatsReport.type_inbound-rtp.packetsDiscarded`
   - `api.RTCStatsReport.type_outbound-rtp.codecId`
   - `api.RTCStatsReport.type_outbound-rtp.nackCount`
@@ -883,7 +861,7 @@
   - `api.RTCStatsReport.type_remote-outbound-rtp.codecId`
   - [`api.ResizeObserverEntry.borderBoxSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry/borderBoxSize)
   - [`api.ResizeObserverEntry.contentBoxSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry/contentBoxSize)
-  - [`api.ResizeObserverSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverSize) +1 +1
+  - [`api.ResizeObserverSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverSize)
   - `api.SVGElement.nonce`
   - [`api.SubmitEvent.submitter`](https://developer.mozilla.org/docs/Web/API/SubmitEvent/submitter)
   - `api.Window.moveTo.relative-multi-screen`
@@ -901,14 +879,14 @@
   - [`api.structuredClone`](https://developer.mozilla.org/docs/Web/API/structuredClone)
   - `css.at-rules.import.layer`
   - [`css.at-rules.layer`](https://developer.mozilla.org/docs/Web/CSS/@layer)
-  - [`css.properties.accent-color`](https://developer.mozilla.org/docs/Web/CSS/accent-color) +1
+  - [`css.properties.accent-color`](https://developer.mozilla.org/docs/Web/CSS/accent-color)
   - `css.properties.align-items.flex_context.start_end`
   - `css.properties.align-self.flex_context.start_end`
-  - [`css.properties.appearance`](https://developer.mozilla.org/docs/Web/CSS/appearance) +1
+  - [`css.properties.appearance`](https://developer.mozilla.org/docs/Web/CSS/appearance)
   - [`css.properties.backface-visibility`](https://developer.mozilla.org/docs/Web/CSS/backface-visibility)
   - `css.properties.background-attachment.fixed`
   - `css.properties.background-attachment.local`
-  - [`css.properties.contain`](https://developer.mozilla.org/docs/Web/CSS/contain) +1 +1 +1 +1 +1 +1
+  - [`css.properties.contain`](https://developer.mozilla.org/docs/Web/CSS/contain)
   - `css.properties.flex-basis.content`
   - `css.properties.hyphenate-character.auto`
   - `css.properties.justify-content.flex_context.start_end`
@@ -916,17 +894,17 @@
   - [`css.properties.offset-path`](https://developer.mozilla.org/docs/Web/CSS/offset-path)
   - `css.properties.overflow-wrap.anywhere`
   - [`css.properties.print-color-adjust`](https://developer.mozilla.org/docs/Web/CSS/print-color-adjust)
-  - [`css.properties.scroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior) +1 +1
+  - [`css.properties.scroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior)
   - `css.properties.text-align.match-parent`
   - [`css.properties.text-combine-upright`](https://developer.mozilla.org/docs/Web/CSS/text-combine-upright)
-  - [`css.properties.text-decoration-skip-ink`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink) +1 +1
+  - [`css.properties.text-decoration-skip-ink`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink)
   - [`css.properties.text-emphasis`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis)
   - [`css.properties.text-emphasis-color`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color)
   - [`css.properties.text-emphasis-position`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position)
   - [`css.properties.text-emphasis-style`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style)
-  - [`css.selectors.backdrop`](https://developer.mozilla.org/docs/Web/CSS/::backdrop) +1
+  - [`css.selectors.backdrop`](https://developer.mozilla.org/docs/Web/CSS/::backdrop)
   - [`css.selectors.focus-visible`](https://developer.mozilla.org/docs/Web/CSS/:focus-visible)
-  - [`html.elements.dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) +1
+  - [`html.elements.dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog)
   - `html.elements.img.loading`
   - [`http.headers.Content-Security-Policy.strict-dynamic`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#strict-dynamic)
   - [`javascript.builtins.Array.at`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/at)
@@ -960,7 +938,7 @@
   - `api.Navigator.canShare.data_text_parameter`
   - `api.RTCStatsReport.type_remote-inbound-rtp.roundTripTime`
   - [`css.properties.color-scheme`](https://developer.mozilla.org/docs/Web/CSS/color-scheme)
-  - [`css.properties.font-synthesis`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis) +1
+  - [`css.properties.font-synthesis`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis)
   - `html.elements.meta.name.color-scheme`
 
 ## Jan 2022
@@ -973,14 +951,14 @@
 ### These Features became stable across all major browsers:
   - [`api.HTMLElement.inputMode`](https://developer.mozilla.org/docs/Web/API/HTMLElement/inputMode)
   - [`api.Navigator.storage`](https://developer.mozilla.org/docs/Web/API/Navigator/storage)
-  - [`api.StorageManager`](https://developer.mozilla.org/docs/Web/API/StorageManager) +1 +1
+  - [`api.StorageManager`](https://developer.mozilla.org/docs/Web/API/StorageManager)
   - [`api.WorkerNavigator.storage`](https://developer.mozilla.org/docs/Web/API/WorkerNavigator/storage)
   - [`api.crossOriginIsolated`](https://developer.mozilla.org/docs/Web/API/crossOriginIsolated)
   - [`http.headers.Cross-Origin-Embedder-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)
   - [`http.headers.Cross-Origin-Opener-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
-  - [`javascript.builtins.Atomics`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`javascript.builtins.Atomics`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics)
   - `javascript.builtins.DataView.DataView.sharedarraybuffer_support`
-  - [`javascript.builtins.SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) +1 +1 +1 +1
+  - [`javascript.builtins.SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
   - `webassembly.api.Memory.Memory.shared`
   - `webassembly.threads-and-atomics`
 
@@ -1020,7 +998,7 @@
   - {'browser':'edge','version':'96'}
   - {'browser':'firefox','version':'94'}
 ### These Features became stable across all major browsers:
-  - [`api.PerformanceNavigationTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.PerformanceNavigationTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming)
   - [`api.SVGAnimationElement.beginEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/beginEvent_event)
   - [`api.SVGAnimationElement.endEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/endEvent_event)
   - [`api.SVGAnimationElement.repeatEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeatEvent_event)
@@ -1042,33 +1020,25 @@
   - `api.Crypto.subtle.secure_context_required`
   - [`api.EXT_color_buffer_float`](https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_float)
   - `api.EventTarget.addEventListener.options_parameter.options_signal_parameter`
-  - [`api.FormDataEvent`](https://developer.mozilla.org/docs/Web/API/FormDataEvent) +1 +1
-  - `api.HTMLCanvasElement.getContext.webgl2_context` +1 +1 +1
+  - [`api.FormDataEvent`](https://developer.mozilla.org/docs/Web/API/FormDataEvent)
+  - `api.HTMLCanvasElement.getContext.webgl2_context`
   - [`api.HTMLFormElement.formdata_event`](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event)
   - [`api.IDBCursor.request`](https://developer.mozilla.org/docs/Web/API/IDBCursor/request)
   - [`api.IDBTransaction.commit`](https://developer.mozilla.org/docs/Web/API/IDBTransaction/commit)
-  - [`api.ImageBitmap`](https://developer.mozilla.org/docs/Web/API/ImageBitmap) +1 +1 +1
+  - [`api.ImageBitmap`](https://developer.mozilla.org/docs/Web/API/ImageBitmap)
   - [`api.MediaError.message`](https://developer.mozilla.org/docs/Web/API/MediaError/message)
-  - [`api.MediaSession`](https://developer.mozilla.org/docs/Web/API/MediaSession) +1 +1 +1
-  - `api.MediaSession.setActionHandler.nexttrack_type`
-  - `api.MediaSession.setActionHandler.pause_type`
-  - `api.MediaSession.setActionHandler.play_type`
-  - `api.MediaSession.setActionHandler.previoustrack_type`
-  - `api.MediaSession.setActionHandler.seekbackward_type`
-  - `api.MediaSession.setActionHandler.seekforward_type`
-  - `api.MediaSession.setActionHandler.seekto_type`
-  - `api.MediaSession.setActionHandler.stop_type` +1
+  - [`api.MediaSession`](https://developer.mozilla.org/docs/Web/API/MediaSession)
   - [`api.Navigator.mediaSession`](https://developer.mozilla.org/docs/Web/API/Navigator/mediaSession)
   - `api.Navigator.share.data_text_parameter`
   - [`api.Performance.timeOrigin`](https://developer.mozilla.org/docs/Web/API/Performance/timeOrigin)
   - [`api.PerformanceObserver.takeRecords`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords)
   - [`api.SecurityPolicyViolationEvent.disposition`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent/disposition)
   - [`api.SecurityPolicyViolationEvent.sample`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent/sample)
-  - [`api.SubmitEvent`](https://developer.mozilla.org/docs/Web/API/SubmitEvent) +1
+  - [`api.SubmitEvent`](https://developer.mozilla.org/docs/Web/API/SubmitEvent)
   - `api.SubtleCrypto.secure_context_required`
   - [`api.WEBGL_color_buffer_float`](https://developer.mozilla.org/docs/Web/API/WEBGL_color_buffer_float)
-  - [`api.WEBGL_draw_buffers`](https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers) +1
-  - [`api.WebGL2RenderingContext`](https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.WEBGL_draw_buffers`](https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers)
+  - [`api.WebGL2RenderingContext`](https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext)
   - [`api.WebGLQuery`](https://developer.mozilla.org/docs/Web/API/WebGLQuery)
   - [`api.WebGLSampler`](https://developer.mozilla.org/docs/Web/API/WebGLSampler)
   - [`api.WebGLSync`](https://developer.mozilla.org/docs/Web/API/WebGLSync)
@@ -1076,7 +1046,7 @@
   - [`api.WebGLVertexArrayObject`](https://developer.mozilla.org/docs/Web/API/WebGLVertexArrayObject)
   - [`api.XMLHttpRequest.send.body_URLSearchParams_type`](https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#URLSearchParams)
   - [`api.createImageBitmap`](https://developer.mozilla.org/docs/Web/API/createImageBitmap)
-  - [`css.properties.aspect-ratio`](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio) +1
+  - [`css.properties.aspect-ratio`](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio)
   - [`css.properties.border-end-end-radius`](https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius)
   - [`css.properties.border-end-start-radius`](https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius)
   - [`css.properties.border-start-end-radius`](https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius)
@@ -1104,20 +1074,20 @@
   - [`css.properties.scroll-margin-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline)
   - [`css.properties.scroll-margin-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end)
   - [`css.properties.scroll-margin-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start)
-  - [`css.properties.scroll-padding-block`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block) +1
-  - [`css.properties.scroll-padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end) +1
-  - [`css.properties.scroll-padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start) +1
-  - [`css.properties.scroll-padding-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline) +1
-  - [`css.properties.scroll-padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end) +1
-  - [`css.properties.scroll-padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start) +1
+  - [`css.properties.scroll-padding-block`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block)
+  - [`css.properties.scroll-padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end)
+  - [`css.properties.scroll-padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start)
+  - [`css.properties.scroll-padding-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline)
+  - [`css.properties.scroll-padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end)
+  - [`css.properties.scroll-padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start)
   - `css.selectors.link.not_match_link`
   - `css.selectors.visited.not_match_link`
   - `css.types.image.gradient.linear-gradient.premultiplied_gradients`
   - `css.types.image.gradient.radial-gradient.premultiplied_gradients`
   - `html.elements.img.aspect_ratio_computed_from_attributes`
   - `http.headers.Referrer-Policy.default_strict-origin-when-cross-origin`
-  - [`javascript.builtins.BigInt64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array) +1
-  - [`javascript.builtins.BigUint64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array) +1
+  - [`javascript.builtins.BigInt64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array)
+  - [`javascript.builtins.BigUint64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array)
   - [`javascript.builtins.DataView.getBigInt64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64)
   - [`javascript.builtins.DataView.getBigUint64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64)
   - [`javascript.builtins.DataView.setBigInt64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64)
@@ -1145,29 +1115,29 @@
   - [`webextensions.api.browserAction.getBadgeText`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText)
   - [`webextensions.api.browserAction.getPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup)
   - [`webextensions.api.browserAction.getTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle)
-  - [`webextensions.api.browserAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked) +1
+  - [`webextensions.api.browserAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked)
   - [`webextensions.api.browserAction.setBadgeBackgroundColor`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor)
   - [`webextensions.api.browserAction.setBadgeText`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText)
-  - [`webextensions.api.browserAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon) +1
+  - [`webextensions.api.browserAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon)
   - [`webextensions.api.browserAction.setPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup)
   - [`webextensions.api.browserAction.setTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setTitle)
-  - [`webextensions.api.commands.Command`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command) +1
+  - [`webextensions.api.commands.Command`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command)
   - [`webextensions.api.commands.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/getAll)
-  - [`webextensions.api.commands.onCommand`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand) +1
-  - [`webextensions.api.cookies.Cookie`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie) +1
-  - [`webextensions.api.cookies.CookieStore`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore) +1 +1
+  - [`webextensions.api.commands.onCommand`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand)
+  - [`webextensions.api.cookies.Cookie`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie)
+  - [`webextensions.api.cookies.CookieStore`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore)
   - [`webextensions.api.cookies.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/get)
   - [`webextensions.api.cookies.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll)
   - [`webextensions.api.cookies.getAllCookieStores`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores)
   - [`webextensions.api.cookies.remove`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/remove)
   - [`webextensions.api.cookies.sameSiteStatus`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/sameSiteStatus)
-  - [`webextensions.api.cookies.set`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set) +1
-  - [`webextensions.api.events.Event`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event) +1 +1 +1
+  - [`webextensions.api.cookies.set`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set)
+  - [`webextensions.api.events.Event`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event)
   - [`webextensions.api.events.UrlFilter`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter)
   - [`webextensions.api.extension.ViewType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/ViewType)
   - [`webextensions.api.extension.getBackgroundPage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage)
   - [`webextensions.api.extension.getURL`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL)
-  - [`webextensions.api.extension.getViews`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews) +1
+  - [`webextensions.api.extension.getViews`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews)
   - [`webextensions.api.extension.inIncognitoContext`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext)
   - [`webextensions.api.extension.isAllowedFileSchemeAccess`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess)
   - [`webextensions.api.extension.isAllowedIncognitoAccess`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess)
@@ -1180,8 +1150,8 @@
   - [`webextensions.api.pageAction.ImageDataType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType)
   - [`webextensions.api.pageAction.getPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup)
   - [`webextensions.api.pageAction.getTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle)
-  - [`webextensions.api.pageAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked) +1
-  - [`webextensions.api.pageAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon) +1
+  - [`webextensions.api.pageAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked)
+  - [`webextensions.api.pageAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon)
   - [`webextensions.api.pageAction.setPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup)
   - [`webextensions.api.pageAction.setTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle)
   - [`webextensions.api.permissions.Permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions)
@@ -1191,7 +1161,7 @@
   - [`webextensions.api.permissions.onRemoved`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved)
   - [`webextensions.api.permissions.remove`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove)
   - [`webextensions.api.permissions.request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request)
-  - [`webextensions.api.runtime.MessageSender`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender) +1 +1 +1 +1
+  - [`webextensions.api.runtime.MessageSender`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender)
   - [`webextensions.api.runtime.OnInstalledReason`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason)
   - [`webextensions.api.runtime.PlatformArch`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch)
   - [`webextensions.api.runtime.PlatformInfo`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo)
@@ -1215,7 +1185,7 @@
   - [`webextensions.api.runtime.reload`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/reload)
   - [`webextensions.api.runtime.sendMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage)
   - [`webextensions.api.runtime.sendNativeMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage)
-  - [`webextensions.api.storage.StorageArea`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea) +1 +1 +1 +1 +1
+  - [`webextensions.api.storage.StorageArea`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea)
   - [`webextensions.api.storage.StorageChange`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange)
   - [`webextensions.api.storage.local`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local)
   - [`webextensions.api.storage.onChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged)
@@ -1240,10 +1210,10 @@
   - [`webextensions.api.tabs.captureVisibleTab`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab)
   - [`webextensions.api.tabs.connect`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect)
   - `webextensions.api.tabs.connect.connectInfo.frameId`
-  - [`webextensions.api.tabs.create`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create) +1 +1 +1 +1 +1
+  - [`webextensions.api.tabs.create`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create)
   - [`webextensions.api.tabs.detectLanguage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage)
   - [`webextensions.api.tabs.duplicate`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate)
-  - [`webextensions.api.tabs.executeScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript) +1
+  - [`webextensions.api.tabs.executeScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript)
   - [`webextensions.api.tabs.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get)
   - [`webextensions.api.tabs.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent)
   - [`webextensions.api.tabs.getZoom`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom)
@@ -1280,7 +1250,7 @@
   - [`webextensions.api.tabs.removeCSS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS)
   - [`webextensions.api.tabs.sendMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage)
   - [`webextensions.api.tabs.setZoom`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom)
-  - [`webextensions.api.tabs.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update) +1 +1 +1
+  - [`webextensions.api.tabs.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update)
   - [`webextensions.api.webNavigation.getAllFrames`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames)
   - [`webextensions.api.webNavigation.getFrame`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame)
   - [`webextensions.api.webNavigation.onBeforeNavigate`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate)
@@ -1291,32 +1261,32 @@
   - [`webextensions.api.windows.CreateType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/CreateType)
   - [`webextensions.api.windows.WINDOW_ID_CURRENT`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT)
   - [`webextensions.api.windows.WINDOW_ID_NONE`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE)
-  - [`webextensions.api.windows.Window`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`webextensions.api.windows.Window`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window)
   - [`webextensions.api.windows.WindowType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowType)
-  - [`webextensions.api.windows.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get) +1
-  - [`webextensions.api.windows.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll) +1
-  - [`webextensions.api.windows.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent) +1
-  - [`webextensions.api.windows.getLastFocused`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused) +1
+  - [`webextensions.api.windows.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get)
+  - [`webextensions.api.windows.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll)
+  - [`webextensions.api.windows.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent)
+  - [`webextensions.api.windows.getLastFocused`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused)
   - [`webextensions.api.windows.onCreated`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated)
   - [`webextensions.api.windows.onFocusChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged)
-  - [`webextensions.api.windows.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update) +1
+  - [`webextensions.api.windows.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update)
   - [`webextensions.manifest.author`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author)
-  - [`webextensions.manifest.background`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background) +1 +1
-  - [`webextensions.manifest.browser_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) +1 +1 +1
-  - [`webextensions.manifest.chrome_url_overrides`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides) +1
+  - [`webextensions.manifest.background`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background)
+  - [`webextensions.manifest.browser_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action)
+  - [`webextensions.manifest.chrome_url_overrides`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
   - [`webextensions.manifest.commands`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands)
-  - [`webextensions.manifest.content_scripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) +1 +1 +1 +1 +1 +1
+  - [`webextensions.manifest.content_scripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts)
   - [`webextensions.manifest.content_security_policy`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy)
   - [`webextensions.manifest.default_locale`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/default_locale)
   - [`webextensions.manifest.description`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description)
   - [`webextensions.manifest.homepage_url`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url)
   - [`webextensions.manifest.icons`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons)
-  - [`webextensions.manifest.manifest_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version) +1
+  - [`webextensions.manifest.manifest_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version)
   - [`webextensions.manifest.name`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name)
-  - [`webextensions.manifest.optional_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) +1 +1 +1 +1 +1 +1
-  - [`webextensions.manifest.options_ui`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) +1
-  - [`webextensions.manifest.page_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) +1 +1 +1
-  - [`webextensions.manifest.permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`webextensions.manifest.optional_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions)
+  - [`webextensions.manifest.options_ui`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui)
+  - [`webextensions.manifest.page_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action)
+  - [`webextensions.manifest.permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions)
   - [`webextensions.manifest.short_name`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name)
   - [`webextensions.manifest.version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version)
   - [`webextensions.manifest.web_accessible_resources`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)
@@ -1333,7 +1303,7 @@
   - {'browser':'safari','version':'15'}
   - {'browser':'safari_ios','version':'15'}
 ### These Features became stable across all major browsers:
-  - [`api.VisualViewport`](https://developer.mozilla.org/docs/Web/API/VisualViewport) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.VisualViewport`](https://developer.mozilla.org/docs/Web/API/VisualViewport)
   - [`api.Window.visualViewport`](https://developer.mozilla.org/docs/Web/API/Window/visualViewport)
   - [`css.properties.tab-size`](https://developer.mozilla.org/docs/Web/CSS/tab-size)
   - [`javascript.builtins.Intl.DateTimeFormat.formatRange`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange)
@@ -1359,7 +1329,7 @@
 
 ## Jun 2021
 ### These Features became stable across all major browsers:
-  - [`api.RTCStatsReport.type_remote-outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_outbound_rtp) +1 +1
+  - [`api.RTCStatsReport.type_remote-outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_outbound_rtp)
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.IntlLegacyConstructedSymbol`
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.IntlLegacyConstructedSymbol`
 
@@ -1369,7 +1339,7 @@
   - {'browser':'edge','version':'91'}
   - {'browser':'firefox','version':'89'}
 ### These Features became stable across all major browsers:
-  - [`api.AbstractRange`](https://developer.mozilla.org/docs/Web/API/AbstractRange) +1 +1 +1 +1 +1
+  - [`api.AbstractRange`](https://developer.mozilla.org/docs/Web/API/AbstractRange)
   - [`api.AnalyserNode.AnalyserNode`](https://developer.mozilla.org/docs/Web/API/AnalyserNode/AnalyserNode)
   - [`api.AnalyserNode.getFloatTimeDomainData`](https://developer.mozilla.org/docs/Web/API/AnalyserNode/getFloatTimeDomainData)
   - [`api.AudioBuffer.AudioBuffer`](https://developer.mozilla.org/docs/Web/API/AudioBuffer/AudioBuffer)
@@ -1377,23 +1347,22 @@
   - [`api.AudioBuffer.copyToChannel`](https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyToChannel)
   - [`api.AudioBufferSourceNode.AudioBufferSourceNode`](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/AudioBufferSourceNode)
   - [`api.AudioBufferSourceNode.detune`](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/detune)
-  - [`api.AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext) +1
-  - `api.AudioContext.AudioContext.options_sampleRate_parameter` +1 +1
+  - [`api.AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext)
   - [`api.AudioDestinationNode.maxChannelCount`](https://developer.mozilla.org/docs/Web/API/AudioDestinationNode/maxChannelCount)
-  - [`api.AudioParamMap`](https://developer.mozilla.org/docs/Web/API/AudioParamMap) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.AudioParamMap`](https://developer.mozilla.org/docs/Web/API/AudioParamMap)
   - [`api.AudioWorklet`](https://developer.mozilla.org/docs/Web/API/AudioWorklet)
-  - [`api.AudioWorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/AudioWorkletGlobalScope) +1 +1 +1 +1
-  - [`api.AudioWorkletNode`](https://developer.mozilla.org/docs/Web/API/AudioWorkletNode) +1 +1 +1 +1
-  - [`api.AudioWorkletProcessor`](https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor) +1 +1
-  - [`api.BaseAudioContext`](https://developer.mozilla.org/docs/Web/API/BaseAudioContext) +1 +1 +1 +1
+  - [`api.AudioWorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/AudioWorkletGlobalScope)
+  - [`api.AudioWorkletNode`](https://developer.mozilla.org/docs/Web/API/AudioWorkletNode)
+  - [`api.AudioWorkletProcessor`](https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor)
+  - [`api.BaseAudioContext`](https://developer.mozilla.org/docs/Web/API/BaseAudioContext)
   - `api.BaseAudioContext.decodeAudioData.returns_promise`
   - [`api.BiquadFilterNode.BiquadFilterNode`](https://developer.mozilla.org/docs/Web/API/BiquadFilterNode/BiquadFilterNode)
   - [`api.Blob.stream`](https://developer.mozilla.org/docs/Web/API/Blob/stream)
-  - [`api.CSSConditionRule`](https://developer.mozilla.org/docs/Web/API/CSSConditionRule) +1
+  - [`api.CSSConditionRule`](https://developer.mozilla.org/docs/Web/API/CSSConditionRule)
   - [`api.CSSGroupingRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule)
   - [`api.ChannelMergerNode.ChannelMergerNode`](https://developer.mozilla.org/docs/Web/API/ChannelMergerNode/ChannelMergerNode)
   - [`api.ChannelSplitterNode.ChannelSplitterNode`](https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode/ChannelSplitterNode)
-  - [`api.ConstantSourceNode`](https://developer.mozilla.org/docs/Web/API/ConstantSourceNode) +1 +1
+  - [`api.ConstantSourceNode`](https://developer.mozilla.org/docs/Web/API/ConstantSourceNode)
   - [`api.ConvolverNode.ConvolverNode`](https://developer.mozilla.org/docs/Web/API/ConvolverNode/ConvolverNode)
   - [`api.DataTransfer.DataTransfer`](https://developer.mozilla.org/docs/Web/API/DataTransfer/DataTransfer)
   - [`api.DelayNode.DelayNode`](https://developer.mozilla.org/docs/Web/API/DelayNode/DelayNode)
@@ -1402,14 +1371,13 @@
   - [`api.GainNode.GainNode`](https://developer.mozilla.org/docs/Web/API/GainNode/GainNode)
   - [`api.HTMLAreaElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy)
   - [`api.HTMLLinkElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/referrerPolicy)
-  - [`api.IIRFilterNode`](https://developer.mozilla.org/docs/Web/API/IIRFilterNode) +1 +1
+  - [`api.IIRFilterNode`](https://developer.mozilla.org/docs/Web/API/IIRFilterNode)
   - [`api.MediaElementAudioSourceNode.MediaElementAudioSourceNode`](https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode)
-  - [`api.MediaRecorder`](https://developer.mozilla.org/docs/Web/API/MediaRecorder) +1
-  - `api.MediaRecorder.MediaRecorder.options_parameter` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaRecorder`](https://developer.mozilla.org/docs/Web/API/MediaRecorder)
   - [`api.MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode)
   - [`api.MediaStreamAudioSourceNode.MediaStreamAudioSourceNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceNode/MediaStreamAudioSourceNode)
   - [`api.OES_fbo_render_mipmap`](https://developer.mozilla.org/docs/Web/API/OES_fbo_render_mipmap)
-  - [`api.OfflineAudioContext`](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext) +1 +1
+  - [`api.OfflineAudioContext`](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext)
   - [`api.OscillatorNode.OscillatorNode`](https://developer.mozilla.org/docs/Web/API/OscillatorNode/OscillatorNode)
   - [`api.PannerNode.PannerNode`](https://developer.mozilla.org/docs/Web/API/PannerNode/PannerNode)
   - [`api.PannerNode.orientationX`](https://developer.mozilla.org/docs/Web/API/PannerNode/orientationX)
@@ -1432,12 +1400,12 @@
   - [`api.Request.formData`](https://developer.mozilla.org/docs/Web/API/Request/formData)
   - [`api.Response.formData`](https://developer.mozilla.org/docs/Web/API/Response/formData)
   - [`api.StaticRange.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange/StaticRange)
-  - [`api.StereoPannerNode`](https://developer.mozilla.org/docs/Web/API/StereoPannerNode) +1 +1
+  - [`api.StereoPannerNode`](https://developer.mozilla.org/docs/Web/API/StereoPannerNode)
   - [`api.TextEncoder.encodeInto`](https://developer.mozilla.org/docs/Web/API/TextEncoder/encodeInto)
   - [`api.URL.URL`](https://developer.mozilla.org/docs/Web/API/URL/URL)
   - [`api.WEBGL_compressed_texture_s3tc_srgb`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb)
   - [`api.WaveShaperNode.WaveShaperNode`](https://developer.mozilla.org/docs/Web/API/WaveShaperNode/WaveShaperNode)
-  - [`api.Worklet`](https://developer.mozilla.org/docs/Web/API/Worklet) +1
+  - [`api.Worklet`](https://developer.mozilla.org/docs/Web/API/Worklet)
   - [`api.WorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/WorkletGlobalScope)
   - `css.at-rules.supports.selector`
   - [`css.properties.border-block`](https://developer.mozilla.org/docs/Web/CSS/border-block)
@@ -1477,15 +1445,15 @@
   - [`css.selectors.file-selector-button`](https://developer.mozilla.org/docs/Web/CSS/::file-selector-button)
   - [`html.elements.input.type_date`](https://developer.mozilla.org/docs/Web/HTML/Element/input/date)
   - [`html.elements.input.type_time`](https://developer.mozilla.org/docs/Web/HTML/Element/input/time)
-  - [`javascript.builtins.FinalizationRegistry`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) +1 +1 +1
+  - [`javascript.builtins.FinalizationRegistry`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry)
   - `javascript.builtins.Intl.Collator.Collator.options_collation_parameter`
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_calendar_parameter`
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_dateStyle_parameter`
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_fractionalSecondDigits_parameter`
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_numberingSystem_parameter`
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_timeStyle_parameter`
-  - [`javascript.builtins.Intl.DisplayNames`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) +1 +1 +1 +1
-  - [`javascript.builtins.Intl.ListFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) +1 +1 +1 +1 +1
+  - [`javascript.builtins.Intl.DisplayNames`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)
+  - [`javascript.builtins.Intl.ListFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat)
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_compactDisplay_parameter`
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_currencyDisplay_parameter`
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_currencySign_parameter`
@@ -1493,7 +1461,7 @@
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_signDisplay_parameter`
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_unitDisplay_parameter`
   - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_unit_parameter`
-  - [`javascript.builtins.WeakRef`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) +1 +1
+  - [`javascript.builtins.WeakRef`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef)
   - [`javascript.classes.public_class_fields`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_fields)
   - [`javascript.classes.static_class_fields`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields)
   - [`javascript.statements.export.namespace`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export)
@@ -1528,13 +1496,13 @@
   - `css.properties.clip-path.path`
   - `css.properties.hyphens.auto`
   - `css.properties.touch-action.pinch-zoom`
-  - [`css.selectors.is`](https://developer.mozilla.org/docs/Web/CSS/:is) +1
+  - [`css.selectors.is`](https://developer.mozilla.org/docs/Web/CSS/:is)
   - `css.selectors.not.selector_list`
-  - [`css.selectors.where`](https://developer.mozilla.org/docs/Web/CSS/:where) +1
+  - [`css.selectors.where`](https://developer.mozilla.org/docs/Web/CSS/:where)
   - [`css.types.basic-shape.path.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path)
   - `html.elements.a.implicit_noopener`
   - `html.elements.area.implicit_noopener`
-  - [`http.headers.Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy) +1 +1
+  - [`http.headers.Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy)
 
 ## Jan 2021
 ### Browsers released:
@@ -1563,9 +1531,9 @@
   - `css.properties.hyphens.language_spanish`
   - `css.properties.text-decoration-thickness.auto`
   - `css.properties.text-decoration-thickness.from-font`
-  - [`css.properties.text-underline-offset`](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset) +1
+  - [`css.properties.text-underline-offset`](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset)
   - `css.properties.text-underline-position.from-font`
-  - [`css.types.image.gradient.conic-gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient) +1
+  - [`css.types.image.gradient.conic-gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient)
   - [`css.types.image.gradient.repeating-conic-gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient)
 
 ## Nov 2020
@@ -1578,7 +1546,7 @@
   - [`api.DocumentFragment.replaceChildren`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
   - [`api.Element.replaceChildren`](https://developer.mozilla.org/docs/Web/API/Element/replaceChildren)
   - [`api.Element.scrollLeft`](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
-  - [`api.MediaMetadata`](https://developer.mozilla.org/docs/Web/API/MediaMetadata) +1 +1 +1 +1 +1
+  - [`api.MediaMetadata`](https://developer.mozilla.org/docs/Web/API/MediaMetadata)
   - [`css.selectors.marker`](https://developer.mozilla.org/docs/Web/CSS/::marker)
 
 ## Oct 2020
@@ -1590,9 +1558,9 @@
   - [`api.AudioScheduledSourceNode`](https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode)
   - [`api.Blob.arrayBuffer`](https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer)
   - [`api.Blob.text`](https://developer.mozilla.org/docs/Web/API/Blob/text)
-  - [`api.BlobEvent`](https://developer.mozilla.org/docs/Web/API/BlobEvent) +1 +1
+  - [`api.BlobEvent`](https://developer.mozilla.org/docs/Web/API/BlobEvent)
   - [`api.Document.getAnimations`](https://developer.mozilla.org/docs/Web/API/Document/getAnimations)
-  - [`api.DragEvent`](https://developer.mozilla.org/docs/Web/API/DragEvent) +1 +1
+  - [`api.DragEvent`](https://developer.mozilla.org/docs/Web/API/DragEvent)
   - [`api.EXT_color_buffer_half_float`](https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_half_float)
   - `api.Element.animate.options_pseudoElement_parameter`
   - `api.Element.scroll.options_behavior_parameter`
@@ -1607,14 +1575,14 @@
   - [`api.KeyframeEffect.pseudoElement`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/pseudoElement)
   - `api.MediaQueryList.EventTarget_inheritance`
   - [`api.MediaQueryList.change_event`](https://developer.mozilla.org/docs/Web/API/MediaQueryList/change_event)
-  - [`api.MediaQueryListEvent`](https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent) +1 +1 +1
+  - [`api.MediaQueryListEvent`](https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent)
   - [`api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent`](https://developer.mozilla.org/docs/Web/API/OfflineAudioCompletionEvent/OfflineAudioCompletionEvent)
   - `api.RTCStatsReport.type_inbound-rtp.kind`
   - `api.RTCStatsReport.type_outbound-rtp.kind`
   - `api.RTCStatsReport.type_remote-inbound-rtp.kind`
   - [`api.ShadowRoot.getAnimations`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/getAnimations)
   - [`api.URLSearchParams.delete`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
-  - [`api.WEBGL_debug_shaders`](https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders) +1
+  - [`api.WEBGL_debug_shaders`](https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders)
   - `api.Window.scroll.options_behavior_parameter`
   - `api.Window.scrollBy.options_behavior_parameter`
   - `api.Window.scrollTo.options_behavior_parameter`
@@ -1630,13 +1598,10 @@
   - `html.elements.link.referrerpolicy`
   - `html.elements.video.aspect_ratio_computed_from_attributes`
   - `http.headers.Referer.length_limit_4096B`
-  - [`javascript.builtins.AggregateError`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) +1 +1
-  - [`javascript.builtins.BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt) +1 +1 +1 +1
-  - `javascript.builtins.BigInt.toLocaleString.locales_parameter`
-  - `javascript.builtins.BigInt.toLocaleString.options_parameter` +1 +1
-  - [`javascript.builtins.Intl.Locale`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`javascript.builtins.Intl.RelativeTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) +1 +1 +1 +1
-  - `javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions.numberingSystem` +1
+  - [`javascript.builtins.AggregateError`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError)
+  - [`javascript.builtins.BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
+  - [`javascript.builtins.Intl.Locale`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale)
+  - [`javascript.builtins.Intl.RelativeTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat)
   - [`javascript.builtins.Promise.any`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
   - [`javascript.builtins.Symbol.toStringTag.dom_objects`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects)
   - [`javascript.operators.logical_and_assignment`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment)
@@ -1668,19 +1633,19 @@
   - [`api.Animation.remove_filling_animation`](https://developer.mozilla.org/docs/web/api/web_animations_api/using_the_web_animations_api#automatically_removing_filling_animations)
   - [`api.Animation.replaceState`](https://developer.mozilla.org/docs/Web/API/Animation/replaceState)
   - [`api.Animation.timeline`](https://developer.mozilla.org/docs/Web/API/Animation/timeline)
-  - [`api.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent) +1 +1 +1
-  - [`api.AnimationTimeline`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline) +1
-  - [`api.CSSAnimation`](https://developer.mozilla.org/docs/Web/API/CSSAnimation) +1
-  - [`api.CSSTransition`](https://developer.mozilla.org/docs/Web/API/CSSTransition) +1
+  - [`api.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent)
+  - [`api.AnimationTimeline`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline)
+  - [`api.CSSAnimation`](https://developer.mozilla.org/docs/Web/API/CSSAnimation)
+  - [`api.CSSTransition`](https://developer.mozilla.org/docs/Web/API/CSSTransition)
   - `api.CanvasPattern.setTransform.dommatrix`
   - [`api.Document.timeline`](https://developer.mozilla.org/docs/Web/API/Document/timeline)
-  - [`api.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline) +1
+  - [`api.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline)
   - [`api.Element.animate.implicit_tofrom`](https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes)
   - [`api.Element.getAnimations`](https://developer.mozilla.org/docs/Web/API/Element/getAnimations)
   - [`api.FileReader.loadstart_event`](https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event)
   - [`api.KeyframeEffect.getKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/getKeyframes)
   - [`api.KeyframeEffect.setKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes)
-  - [`api.RTCStatsReport.type_data-channel`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#data_channel) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_data-channel`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#data_channel)
   - [`css.properties.ruby-position`](https://developer.mozilla.org/docs/Web/CSS/ruby-position)
   - [`css.types.global_keywords.revert`](https://developer.mozilla.org/docs/Web/CSS/revert)
   - `html.elements.iframe.sandbox.allow-top-navigation-by-user-activation`
@@ -1714,7 +1679,7 @@
   - {'browser':'firefox','version':'76'}
 ### These Features became stable across all major browsers:
   - [`api.ServiceWorkerGlobalScope.messageerror_event`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/messageerror_event)
-  - [`css.properties.image-orientation`](https://developer.mozilla.org/docs/Web/CSS/image-orientation) +1 +1
+  - [`css.properties.image-orientation`](https://developer.mozilla.org/docs/Web/CSS/image-orientation)
   - [`css.types.clamp`](https://developer.mozilla.org/docs/Web/CSS/clamp)
   - [`css.types.max`](https://developer.mozilla.org/docs/Web/CSS/max)
   - [`css.types.min`](https://developer.mozilla.org/docs/Web/CSS/min)
@@ -1726,11 +1691,11 @@
   - {'browser':'edge','version':'81'}
   - {'browser':'firefox','version':'75'}
 ### These Features became stable across all major browsers:
-  - [`api.Animation`](https://developer.mozilla.org/docs/Web/API/Animation) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.AnimationEffect`](https://developer.mozilla.org/docs/Web/API/AnimationEffect) +1 +1 +1
+  - [`api.Animation`](https://developer.mozilla.org/docs/Web/API/Animation)
+  - [`api.AnimationEffect`](https://developer.mozilla.org/docs/Web/API/AnimationEffect)
   - [`api.AnimationEvent.pseudoElement`](https://developer.mozilla.org/docs/Web/API/AnimationEvent/pseudoElement)
-  - [`api.Clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard) +1
-  - [`api.Element.animate`](https://developer.mozilla.org/docs/Web/API/Element/animate) +1
+  - [`api.Clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard)
+  - [`api.Element.animate`](https://developer.mozilla.org/docs/Web/API/Element/animate)
   - [`api.Element.part`](https://developer.mozilla.org/docs/Web/API/Element/part)
   - [`api.Element.transitionrun_event`](https://developer.mozilla.org/docs/Web/API/Element/transitionrun_event)
   - [`api.Element.transitionstart_event`](https://developer.mozilla.org/docs/Web/API/Element/transitionstart_event)
@@ -1739,10 +1704,10 @@
   - [`api.GeolocationPosition`](https://developer.mozilla.org/docs/Web/API/GeolocationPosition)
   - [`api.GeolocationPositionError`](https://developer.mozilla.org/docs/Web/API/GeolocationPositionError)
   - `api.HTMLIFrameElement.allow`
-  - [`api.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect) +1 +1
+  - [`api.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect)
   - [`api.Navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Navigator/clipboard)
-  - [`api.RTCDTMFSender`](https://developer.mozilla.org/docs/Web/API/RTCDTMFSender) +1 +1 +1
-  - [`api.RTCDTMFToneChangeEvent`](https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent) +1 +1
+  - [`api.RTCDTMFSender`](https://developer.mozilla.org/docs/Web/API/RTCDTMFSender)
+  - [`api.RTCDTMFToneChangeEvent`](https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent)
   - [`api.RTCRtpSender.dtmf`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/dtmf)
   - `api.RTCStatsReport.type_candidate-pair.id`
   - `api.RTCStatsReport.type_candidate-pair.timestamp`
@@ -1765,9 +1730,8 @@
   - `api.RTCStatsReport.type_remote-candidate.id`
   - `api.RTCStatsReport.type_remote-candidate.timestamp`
   - `api.RTCStatsReport.type_remote-candidate.type`
-  - [`api.ResizeObserver`](https://developer.mozilla.org/docs/Web/API/ResizeObserver) +1 +1 +1
-  - `api.ResizeObserver.observe.options_box_parameter` +1
-  - [`api.ResizeObserverEntry`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry) +1 +1
+  - [`api.ResizeObserver`](https://developer.mozilla.org/docs/Web/API/ResizeObserver)
+  - [`api.ResizeObserverEntry`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry)
   - `api.SVGLengthList.length`
   - `api.SVGNumberList.length`
   - [`api.SVGPointList.length`](https://developer.mozilla.org/docs/Web/API/SVGPointList/length)
@@ -1780,7 +1744,7 @@
   - `css.properties.opacity.percentages`
   - `css.properties.overflow.multiple_keywords`
   - [`css.properties.tab-size.length`](https://developer.mozilla.org/docs/Web/CSS/length)
-  - [`css.properties.text-underline-position`](https://developer.mozilla.org/docs/Web/CSS/text-underline-position) +1
+  - [`css.properties.text-underline-position`](https://developer.mozilla.org/docs/Web/CSS/text-underline-position)
   - `css.properties.white-space.break-spaces`
   - [`css.selectors.part`](https://developer.mozilla.org/docs/Web/CSS/::part)
   - `css.types.length.Q`
@@ -1791,7 +1755,7 @@
   - [`javascript.grammar.hashbang_comments`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments)
   - [`javascript.operators.nullish_coalescing`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
   - [`javascript.operators.optional_chaining`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
-  - [`webassembly.api.Global`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) +1 +1 +1
+  - [`webassembly.api.Global`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global)
 
 ## Mar 2020
 ### Browsers released:
@@ -1802,10 +1766,10 @@
   - [`api.EXT_sRGB`](https://developer.mozilla.org/docs/Web/API/EXT_sRGB)
   - [`api.HTMLVideoElement.getVideoPlaybackQuality`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/getVideoPlaybackQuality)
   - `api.RTCStatsReport.type_inbound-rtp.ssrc`
-  - [`api.RTCStatsReport.type_local-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#local_candidate) +1 +1 +1 +1 +1
-  - [`api.RTCStatsReport.type_outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#outbound_rtp) +1
-  - [`api.RTCStatsReport.type_remote-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_candidate) +1 +1 +1 +1 +1
-  - [`api.RTCStatsReport.type_remote-inbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_inbound_rtp) +1
+  - [`api.RTCStatsReport.type_local-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#local_candidate)
+  - [`api.RTCStatsReport.type_outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#outbound_rtp)
+  - [`api.RTCStatsReport.type_remote-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_candidate)
+  - [`api.RTCStatsReport.type_remote-inbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_inbound_rtp)
   - [`svg.global_attributes.letter-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/letter-spacing)
   - [`svg.global_attributes.word-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/word-spacing)
 
@@ -1818,26 +1782,26 @@
   - [`api.AudioContext.createMediaStreamDestination`](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamDestination)
   - [`api.AudioParam.maxValue`](https://developer.mozilla.org/docs/Web/API/AudioParam/maxValue)
   - [`api.AudioParam.minValue`](https://developer.mozilla.org/docs/Web/API/AudioParam/minValue)
-  - [`api.BeforeUnloadEvent`](https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent) +1
+  - [`api.BeforeUnloadEvent`](https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent)
   - [`api.CSS.escape_static`](https://developer.mozilla.org/docs/Web/API/CSS/escape_static)
   - [`api.CSS.supports_static`](https://developer.mozilla.org/docs/Web/API/CSS/supports_static)
   - `api.CacheStorage.secure_context_required`
   - [`api.CanvasPattern.setTransform`](https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform)
   - [`api.CanvasRenderingContext2D.getTransform`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getTransform)
-  - [`api.CanvasRenderingContext2D.isPointInStroke`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInStroke) +1
+  - [`api.CanvasRenderingContext2D.isPointInStroke`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInStroke)
   - [`api.CanvasRenderingContext2D.resetTransform`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/resetTransform)
   - `api.CanvasRenderingContext2D.setTransform.matrix_parameter`
   - [`api.CredentialsContainer.store`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
-  - [`api.CustomElementRegistry`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry) +1 +1 +1 +1
+  - [`api.CustomElementRegistry`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry)
   - [`api.DOMException.DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException/DOMException)
-  - [`api.DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.DOMMatrixReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.DOMPoint`](https://developer.mozilla.org/docs/Web/API/DOMPoint) +1 +1 +1 +1 +1 +1 +1
-  - [`api.DOMPointReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly) +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.DOMQuad`](https://developer.mozilla.org/docs/Web/API/DOMQuad) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) +1 +1 +1 +1 +1
+  - [`api.DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
+  - [`api.DOMMatrixReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly)
+  - [`api.DOMPoint`](https://developer.mozilla.org/docs/Web/API/DOMPoint)
+  - [`api.DOMPointReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly)
+  - [`api.DOMQuad`](https://developer.mozilla.org/docs/Web/API/DOMQuad)
+  - [`api.DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect)
   - `api.DOMRectList`
-  - [`api.DOMRectReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly) +1 +1 +1 +1 +1 +1
+  - [`api.DOMRectReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly)
   - [`api.Document.elementsFromPoint`](https://developer.mozilla.org/docs/Web/API/Document/elementsFromPoint)
   - [`api.Document.fonts`](https://developer.mozilla.org/docs/Web/API/Document/fonts)
   - [`api.Element.DOMActivate_event`](https://developer.mozilla.org/docs/Web/API/Element/DOMActivate_event)
@@ -1845,24 +1809,23 @@
   - [`api.Element.attachShadow`](https://developer.mozilla.org/docs/Web/API/Element/attachShadow)
   - [`api.Element.hasPointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/hasPointerCapture)
   - [`api.Element.input_event`](https://developer.mozilla.org/docs/Web/API/Element/input_event)
-  - [`api.Element.scroll`](https://developer.mozilla.org/docs/Web/API/Element/scroll) +1 +1
-  - [`api.Element.scrollBy`](https://developer.mozilla.org/docs/Web/API/Element/scrollBy) +1 +1
+  - [`api.Element.scroll`](https://developer.mozilla.org/docs/Web/API/Element/scroll)
+  - [`api.Element.scrollBy`](https://developer.mozilla.org/docs/Web/API/Element/scrollBy)
   - [`api.Element.scrollIntoView`](https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView)
-  - [`api.Element.scrollTo`](https://developer.mozilla.org/docs/Web/API/Element/scrollTo) +1 +1
+  - [`api.Element.scrollTo`](https://developer.mozilla.org/docs/Web/API/Element/scrollTo)
   - [`api.Element.shadowRoot`](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
   - [`api.Element.slot`](https://developer.mozilla.org/docs/Web/API/Element/slot)
   - [`api.Event.composed`](https://developer.mozilla.org/docs/Web/API/Event/composed)
   - [`api.Event.composedPath`](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
-  - [`api.EventSource`](https://developer.mozilla.org/docs/Web/API/EventSource) +1
-  - `api.EventSource.EventSource.options_withCredentials_parameter` +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.EventSource`](https://developer.mozilla.org/docs/Web/API/EventSource)
   - `api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch`
   - [`api.File.File`](https://developer.mozilla.org/docs/Web/API/File/File)
-  - [`api.FileSystemDirectoryEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry) +1 +1 +1
+  - [`api.FileSystemDirectoryEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry)
   - [`api.FileSystemDirectoryReader.readEntries`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader/readEntries)
-  - [`api.FileSystemEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemEntry) +1 +1 +1 +1 +1 +1
-  - [`api.FileSystemFileEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry) +1
-  - [`api.FontFace`](https://developer.mozilla.org/docs/Web/API/FontFace) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.FontFaceSet`](https://developer.mozilla.org/docs/Web/API/FontFaceSet) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.FileSystemEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemEntry)
+  - [`api.FileSystemFileEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry)
+  - [`api.FontFace`](https://developer.mozilla.org/docs/Web/API/FontFace)
+  - [`api.FontFaceSet`](https://developer.mozilla.org/docs/Web/API/FontFaceSet)
   - `api.Geolocation.secure_context_required`
   - `api.GeolocationCoordinates.secure_context_required`
   - [`api.HTMLAnchorElement.password`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/password)
@@ -1871,9 +1834,9 @@
   - [`api.HTMLAreaElement.username`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/username)
   - [`api.HTMLCanvasElement.captureStream`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/captureStream)
   - `api.HTMLCanvasElement.getContext.bitmaprenderer_context`
-  - `api.HTMLCanvasElement.getContext.webgl_context` +1
-  - [`api.HTMLCanvasElement.toBlob`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toBlob) +1
-  - [`api.HTMLDetailsElement`](https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement) +1 +1
+  - `api.HTMLCanvasElement.getContext.webgl_context`
+  - [`api.HTMLCanvasElement.toBlob`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toBlob)
+  - [`api.HTMLDetailsElement`](https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement)
   - `api.HTMLEmbedElement.align`
   - `api.HTMLEmbedElement.type`
   - [`api.HTMLIFrameElement.srcdoc`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/srcdoc)
@@ -1885,7 +1848,7 @@
   - [`api.HTMLMediaElement.waitingforkey_event`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/waitingforkey_event)
   - [`api.HTMLOListElement.reversed`](https://developer.mozilla.org/docs/Web/API/HTMLOListElement/reversed)
   - [`api.HTMLSelectElement.autocomplete`](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/autocomplete)
-  - [`api.HTMLSlotElement`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement) +1 +1 +1 +1
+  - [`api.HTMLSlotElement`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement)
   - [`api.HTMLTextAreaElement.autocomplete`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/autocomplete)
   - `api.HTMLTextAreaElement.selectionDirection`
   - `api.HTMLTextAreaElement.setRangeText`
@@ -1903,14 +1866,14 @@
   - [`api.IDBObjectStore.openKeyCursor`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openKeyCursor)
   - [`api.IDBTransaction.objectStoreNames`](https://developer.mozilla.org/docs/Web/API/IDBTransaction/objectStoreNames)
   - [`api.IDBVersionChangeEvent.IDBVersionChangeEvent`](https://developer.mozilla.org/docs/Web/API/IDBVersionChangeEvent/IDBVersionChangeEvent)
-  - [`api.ImageBitmapRenderingContext`](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext) +1
+  - [`api.ImageBitmapRenderingContext`](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext)
   - [`api.InputDeviceInfo`](https://developer.mozilla.org/docs/Web/API/InputDeviceInfo)
-  - [`api.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent) +1 +1 +1 +1
+  - [`api.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent)
   - [`api.KeyboardEvent.code`](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/code)
   - `api.KeyboardEvent.getModifierState.key_parameter_altgraph`
   - `api.KeyboardEvent.getModifierState.key_parameter_meta`
   - [`api.KeyboardEvent.isComposing`](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/isComposing)
-  - [`api.MediaCapabilities`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities) +1
+  - [`api.MediaCapabilities`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities)
   - `api.MediaDevices.getUserMedia.secure_context_required`
   - [`api.MediaElementAudioSourceNode.mediaElement`](https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/mediaElement)
   - [`api.MediaKeySession.keystatuseschange_event`](https://developer.mozilla.org/docs/Web/API/MediaKeySession/keystatuseschange_event)
@@ -1926,18 +1889,17 @@
   - [`api.PageTransitionEvent.PageTransitionEvent`](https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/PageTransitionEvent)
   - [`api.Path2D.addPath`](https://developer.mozilla.org/docs/Web/API/Path2D/addPath)
   - [`api.Performance.resourcetimingbufferfull_event`](https://developer.mozilla.org/docs/Web/API/Performance/resourcetimingbufferfull_event)
-  - [`api.PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) +1 +1 +1 +1 +1
-  - [`api.PerformanceObserverEntryList`](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) +1 +1 +1
+  - [`api.PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)
+  - [`api.PerformanceObserverEntryList`](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList)
   - [`api.PointerEvent.tangentialPressure`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tangentialPressure)
   - [`api.ProcessingInstruction.sheet`](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/sheet)
-  - [`api.PromiseRejectionEvent`](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent) +1 +1 +1
-  - [`api.RTCCertificate`](https://developer.mozilla.org/docs/Web/API/RTCCertificate) +1
-  - [`api.RTCDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCDataChannel) +1
-  - `api.RTCDataChannel.binaryType.arraybuffer_value` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.RTCDataChannelEvent`](https://developer.mozilla.org/docs/Web/API/RTCDataChannelEvent) +1 +1
+  - [`api.PromiseRejectionEvent`](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent)
+  - [`api.RTCCertificate`](https://developer.mozilla.org/docs/Web/API/RTCCertificate)
+  - [`api.RTCDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCDataChannel)
+  - [`api.RTCDataChannelEvent`](https://developer.mozilla.org/docs/Web/API/RTCDataChannelEvent)
   - `api.RTCPeerConnection.addIceCandidate.returns_promise`
   - [`api.RTCPeerConnection.addTrack`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTrack)
-  - [`api.RTCPeerConnection.addTransceiver`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver) +1 +1
+  - [`api.RTCPeerConnection.addTransceiver`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver)
   - `api.RTCPeerConnection.createAnswer.returns_promise`
   - [`api.RTCPeerConnection.createDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createDataChannel)
   - `api.RTCPeerConnection.createOffer.returns_promise`
@@ -1955,7 +1917,7 @@
   - `api.RTCPeerConnection.setLocalDescription.returns_promise`
   - `api.RTCPeerConnection.setRemoteDescription.returns_promise`
   - [`api.RTCPeerConnection.track_event`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/track_event)
-  - [`api.RTCRtpReceiver.getSynchronizationSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getSynchronizationSources) +1 +1
+  - [`api.RTCRtpReceiver.getSynchronizationSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getSynchronizationSources)
   - [`api.RTCRtpSender.replaceTrack`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/replaceTrack)
   - [`api.RTCRtpTransceiver.currentDirection`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/currentDirection)
   - [`api.RTCRtpTransceiver.direction`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/direction)
@@ -1963,32 +1925,25 @@
   - [`api.RTCRtpTransceiver.receiver`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/receiver)
   - [`api.RTCRtpTransceiver.sender`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/sender)
   - [`api.RTCRtpTransceiver.stopped`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/stopped)
-  - [`api.RTCStatsReport`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport) +1 +1 +1 +1 +1 +1 +1 +1
-  - `api.RTCStatsReport.type_candidate-pair.bytesReceived`
-  - `api.RTCStatsReport.type_candidate-pair.bytesSent`
-  - `api.RTCStatsReport.type_candidate-pair.localCandidateId`
-  - `api.RTCStatsReport.type_candidate-pair.nominated`
-  - `api.RTCStatsReport.type_candidate-pair.remoteCandidateId`
-  - `api.RTCStatsReport.type_candidate-pair.state`
-  - `api.RTCStatsReport.type_candidate-pair.transportId` +1 +1
-  - [`api.RTCTrackEvent`](https://developer.mozilla.org/docs/Web/API/RTCTrackEvent) +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport)
+  - [`api.RTCTrackEvent`](https://developer.mozilla.org/docs/Web/API/RTCTrackEvent)
   - [`api.ReadableStream.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream/ReadableStream)
   - [`api.ReadableStream.tee`](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)
   - [`api.SVGAnimateElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateElement)
   - [`api.SVGAnimateMotionElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateMotionElement)
   - [`api.SVGAnimateTransformElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateTransformElement)
-  - [`api.SVGAnimationElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.SVGFEDropShadowElement`](https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.SVGGeometryElement`](https://developer.mozilla.org/docs/Web/API/SVGGeometryElement) +1 +1 +1 +1 +1
-  - [`api.SVGMPathElement`](https://developer.mozilla.org/docs/Web/API/SVGMPathElement) +1
+  - [`api.SVGAnimationElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement)
+  - [`api.SVGFEDropShadowElement`](https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement)
+  - [`api.SVGGeometryElement`](https://developer.mozilla.org/docs/Web/API/SVGGeometryElement)
+  - [`api.SVGMPathElement`](https://developer.mozilla.org/docs/Web/API/SVGMPathElement)
   - `api.SVGRadialGradientElement.fr`
   - `api.SVGSVGElement.animationsPaused`
   - [`api.SVGSetElement`](https://developer.mozilla.org/docs/Web/API/SVGSetElement)
-  - [`api.Screen.availLeft`](https://developer.mozilla.org/docs/Web/API/Screen/availLeft) +1
-  - [`api.Screen.availTop`](https://developer.mozilla.org/docs/Web/API/Screen/availTop) +1
+  - [`api.Screen.availLeft`](https://developer.mozilla.org/docs/Web/API/Screen/availLeft)
+  - [`api.Screen.availTop`](https://developer.mozilla.org/docs/Web/API/Screen/availTop)
   - [`api.Selection.modify`](https://developer.mozilla.org/docs/Web/API/Selection/modify)
   - [`api.ServiceWorkerContainer.startMessages`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages)
-  - [`api.ShadowRoot`](https://developer.mozilla.org/docs/Web/API/ShadowRoot) +1 +1 +1 +1 +1 +1 +1
+  - [`api.ShadowRoot`](https://developer.mozilla.org/docs/Web/API/ShadowRoot)
   - [`api.SourceBuffer.changeType`](https://developer.mozilla.org/docs/Web/API/SourceBuffer/changeType)
   - [`api.SubtleCrypto.decrypt`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt)
   - [`api.SubtleCrypto.deriveBits`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
@@ -2004,8 +1959,8 @@
   - `api.SubtleCrypto.worker_support`
   - [`api.SubtleCrypto.wrapKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey)
   - [`api.Text.assignedSlot`](https://developer.mozilla.org/docs/Web/API/Text/assignedSlot)
-  - [`api.TextDecoder`](https://developer.mozilla.org/docs/Web/API/TextDecoder) +1 +1 +1 +1 +1 +1
-  - [`api.TextEncoder`](https://developer.mozilla.org/docs/Web/API/TextEncoder) +1 +1 +1 +1
+  - [`api.TextDecoder`](https://developer.mozilla.org/docs/Web/API/TextDecoder)
+  - [`api.TextEncoder`](https://developer.mozilla.org/docs/Web/API/TextEncoder)
   - [`api.TransitionEvent.pseudoElement`](https://developer.mozilla.org/docs/Web/API/TransitionEvent/pseudoElement)
   - [`api.UIEvent.which`](https://developer.mozilla.org/docs/Web/API/UIEvent/which)
   - [`api.VTTCue.VTTCue`](https://developer.mozilla.org/docs/Web/API/VTTCue/VTTCue)
@@ -2015,7 +1970,7 @@
   - [`api.VTTCue.size`](https://developer.mozilla.org/docs/Web/API/VTTCue/size)
   - [`api.VTTCue.snapToLines`](https://developer.mozilla.org/docs/Web/API/VTTCue/snapToLines)
   - [`api.VTTCue.vertical`](https://developer.mozilla.org/docs/Web/API/VTTCue/vertical)
-  - [`api.WEBGL_compressed_texture_astc`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc) +1
+  - [`api.WEBGL_compressed_texture_astc`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc)
   - [`api.Window.customElements`](https://developer.mozilla.org/docs/Web/API/Window/customElements)
   - [`api.Window.find`](https://developer.mozilla.org/docs/Web/API/Window/find)
   - [`api.Window.languagechange_event`](https://developer.mozilla.org/docs/Web/API/Window/languagechange_event)
@@ -2048,7 +2003,7 @@
   - `css.properties.align-self.flex_context.stretch`
   - [`css.properties.all`](https://developer.mozilla.org/docs/Web/CSS/all)
   - [`css.properties.background-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/background-blend-mode)
-  - [`css.properties.block-size`](https://developer.mozilla.org/docs/Web/CSS/block-size) +1 +1
+  - [`css.properties.block-size`](https://developer.mozilla.org/docs/Web/CSS/block-size)
   - [`css.properties.border-block-end`](https://developer.mozilla.org/docs/Web/CSS/border-block-end)
   - [`css.properties.border-block-end-color`](https://developer.mozilla.org/docs/Web/CSS/border-block-end-color)
   - [`css.properties.border-block-end-style`](https://developer.mozilla.org/docs/Web/CSS/border-block-end-style)
@@ -2065,15 +2020,15 @@
   - [`css.properties.border-inline-start-color`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color)
   - [`css.properties.border-inline-start-style`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style)
   - [`css.properties.border-inline-start-width`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width)
-  - [`css.properties.box-decoration-break`](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break) +1 +1
+  - [`css.properties.box-decoration-break`](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break)
   - [`css.properties.caret-color`](https://developer.mozilla.org/docs/Web/CSS/caret-color)
-  - [`css.properties.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path) +1 +1
+  - [`css.properties.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path)
   - `css.properties.column-count.auto`
   - `css.properties.column-span.all`
   - `css.properties.column-span.none`
   - `css.properties.content.element_replacement`
   - `css.properties.cursor.url_positioning_syntax`
-  - [`css.properties.custom-property.env`](https://developer.mozilla.org/docs/Web/CSS/env()) +1 +1 +1 +1
+  - [`css.properties.custom-property.env`](https://developer.mozilla.org/docs/Web/CSS/env())
   - `css.properties.display.contents`
   - `css.properties.display.flow-root`
   - `css.properties.font.font_stretch_support`
@@ -2081,10 +2036,10 @@
   - [`css.properties.font-smooth`](https://developer.mozilla.org/docs/Web/CSS/font-smooth)
   - `css.properties.font-style.oblique-angle`
   - `css.properties.font-variant.css_fonts_shorthand`
-  - [`css.properties.font-variant-caps`](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps) +1 +1 +1 +1 +1 +1 +1
-  - [`css.properties.font-variant-east-asian`](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`css.properties.font-variant-ligatures`](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`css.properties.font-variant-numeric`](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.properties.font-variant-caps`](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps)
+  - [`css.properties.font-variant-east-asian`](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian)
+  - [`css.properties.font-variant-ligatures`](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures)
+  - [`css.properties.font-variant-numeric`](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric)
   - `css.properties.grid-template.none`
   - `css.properties.grid-template-areas.none`
   - `css.properties.grid-template-columns.auto`
@@ -2097,8 +2052,8 @@
   - `css.properties.grid-template-rows.none`
   - `css.properties.height.max-content`
   - `css.properties.height.min-content`
-  - [`css.properties.image-rendering`](https://developer.mozilla.org/docs/Web/CSS/image-rendering) +1 +1
-  - [`css.properties.inline-size`](https://developer.mozilla.org/docs/Web/CSS/inline-size) +1 +1
+  - [`css.properties.image-rendering`](https://developer.mozilla.org/docs/Web/CSS/image-rendering)
+  - [`css.properties.inline-size`](https://developer.mozilla.org/docs/Web/CSS/inline-size)
   - [`css.properties.isolation`](https://developer.mozilla.org/docs/Web/CSS/isolation)
   - `css.properties.justify-content.flex_context.space-evenly`
   - `css.properties.justify-content.flex_context.stretch`
@@ -2134,22 +2089,22 @@
   - [`css.properties.margin-block-start`](https://developer.mozilla.org/docs/Web/CSS/margin-block-start)
   - [`css.properties.margin-inline-end`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-end)
   - [`css.properties.margin-inline-start`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-start)
-  - [`css.properties.mask-type`](https://developer.mozilla.org/docs/Web/CSS/mask-type) +1 +1
-  - [`css.properties.max-block-size`](https://developer.mozilla.org/docs/Web/CSS/max-block-size) +1 +1
+  - [`css.properties.mask-type`](https://developer.mozilla.org/docs/Web/CSS/mask-type)
+  - [`css.properties.max-block-size`](https://developer.mozilla.org/docs/Web/CSS/max-block-size)
   - `css.properties.max-height.max-content`
   - `css.properties.max-height.min-content`
   - `css.properties.max-height.none`
-  - [`css.properties.max-inline-size`](https://developer.mozilla.org/docs/Web/CSS/max-inline-size) +1 +1
+  - [`css.properties.max-inline-size`](https://developer.mozilla.org/docs/Web/CSS/max-inline-size)
   - `css.properties.max-width.max-content`
   - `css.properties.max-width.min-content`
-  - [`css.properties.min-block-size`](https://developer.mozilla.org/docs/Web/CSS/min-block-size) +1 +1
+  - [`css.properties.min-block-size`](https://developer.mozilla.org/docs/Web/CSS/min-block-size)
   - `css.properties.min-height.max-content`
   - `css.properties.min-height.min-content`
-  - [`css.properties.min-inline-size`](https://developer.mozilla.org/docs/Web/CSS/min-inline-size) +1 +1
+  - [`css.properties.min-inline-size`](https://developer.mozilla.org/docs/Web/CSS/min-inline-size)
   - `css.properties.min-width.max-content`
   - `css.properties.min-width.min-content`
   - [`css.properties.mix-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode)
-  - [`css.properties.object-fit`](https://developer.mozilla.org/docs/Web/CSS/object-fit) +1 +1 +1 +1 +1
+  - [`css.properties.object-fit`](https://developer.mozilla.org/docs/Web/CSS/object-fit)
   - [`css.properties.object-position`](https://developer.mozilla.org/docs/Web/CSS/object-position)
   - `css.properties.overflow.auto`
   - `css.properties.overflow-x.auto`
@@ -2158,25 +2113,25 @@
   - [`css.properties.padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/padding-block-start)
   - [`css.properties.padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-end)
   - [`css.properties.padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-start)
-  - [`css.properties.place-content`](https://developer.mozilla.org/docs/Web/CSS/place-content) +1 +1
-  - [`css.properties.place-items`](https://developer.mozilla.org/docs/Web/CSS/place-items) +1 +1
-  - [`css.properties.place-self`](https://developer.mozilla.org/docs/Web/CSS/place-self) +1 +1
-  - [`css.properties.resize`](https://developer.mozilla.org/docs/Web/CSS/resize) +1
+  - [`css.properties.place-content`](https://developer.mozilla.org/docs/Web/CSS/place-content)
+  - [`css.properties.place-items`](https://developer.mozilla.org/docs/Web/CSS/place-items)
+  - [`css.properties.place-self`](https://developer.mozilla.org/docs/Web/CSS/place-self)
+  - [`css.properties.resize`](https://developer.mozilla.org/docs/Web/CSS/resize)
   - `css.properties.scroll-padding.auto`
-  - [`css.properties.scroll-snap-align`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align) +1 +1 +1 +1
+  - [`css.properties.scroll-snap-align`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align)
   - [`css.properties.shape-image-threshold`](https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold)
   - [`css.properties.shape-margin`](https://developer.mozilla.org/docs/Web/CSS/shape-margin)
-  - [`css.properties.shape-outside`](https://developer.mozilla.org/docs/Web/CSS/shape-outside) +1 +1 +1 +1 +1 +1
+  - [`css.properties.shape-outside`](https://developer.mozilla.org/docs/Web/CSS/shape-outside)
   - `css.properties.text-align.end`
   - `css.properties.text-align.start`
   - `css.properties.text-decoration.includes_color-and-style`
   - [`css.properties.text-decoration-color`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-color)
-  - [`css.properties.text-decoration-line`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line) +1
-  - [`css.properties.text-decoration-style`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style) +1
+  - [`css.properties.text-decoration-line`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line)
+  - [`css.properties.text-decoration-style`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style)
   - `css.properties.text-emphasis-position.left`
   - `css.properties.text-emphasis-position.right`
   - `css.properties.text-orientation.sideways`
-  - [`css.properties.text-rendering`](https://developer.mozilla.org/docs/Web/CSS/text-rendering) +1 +1
+  - [`css.properties.text-rendering`](https://developer.mozilla.org/docs/Web/CSS/text-rendering)
   - [`css.properties.transform-box`](https://developer.mozilla.org/docs/Web/CSS/transform-box)
   - `css.properties.unicode-bidi.isolate`
   - `css.properties.unicode-bidi.isolate-override`
@@ -2185,7 +2140,7 @@
   - `css.properties.width.max-content`
   - `css.properties.width.min-content`
   - `css.properties.width.stretch`
-  - [`css.properties.will-change`](https://developer.mozilla.org/docs/Web/CSS/will-change) +1 +1 +1
+  - [`css.properties.will-change`](https://developer.mozilla.org/docs/Web/CSS/will-change)
   - `css.properties.word-spacing.svg_elements`
   - `css.properties.writing-mode.horizontal-tb`
   - `css.properties.writing-mode.vertical-lr`
@@ -2201,11 +2156,11 @@
   - `css.selectors.indeterminate.radio`
   - `css.selectors.invalid.form`
   - [`css.selectors.placeholder`](https://developer.mozilla.org/docs/Web/CSS/::placeholder)
-  - [`css.selectors.placeholder-shown`](https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown) +1
-  - [`css.selectors.scope`](https://developer.mozilla.org/docs/Web/CSS/:scope) +1
+  - [`css.selectors.placeholder-shown`](https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown)
+  - [`css.selectors.scope`](https://developer.mozilla.org/docs/Web/CSS/:scope)
   - [`css.selectors.slotted`](https://developer.mozilla.org/docs/Web/CSS/::slotted)
   - `css.selectors.valid.form`
-  - [`css.types.basic-shape`](https://developer.mozilla.org/docs/Web/CSS/basic-shape) +1 +1 +1 +1 +1
+  - [`css.types.basic-shape`](https://developer.mozilla.org/docs/Web/CSS/basic-shape)
   - [`css.types.blend-mode`](https://developer.mozilla.org/docs/Web/CSS/blend-mode)
   - `css.types.color.hsl.alpha_parameter`
   - `css.types.color.hsl.space_separated_parameters`
@@ -2224,7 +2179,7 @@
   - [`html.elements.a.rel.noopener`](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noopener)
   - [`html.elements.area.rel.noopener`](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noopener)
   - [`html.elements.bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi)
-  - [`html.elements.details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) +1
+  - [`html.elements.details`](https://developer.mozilla.org/docs/Web/HTML/Element/details)
   - `html.elements.iframe.sandbox.allow-modals`
   - `html.elements.iframe.sandbox.allow-popups-to-escape-sandbox`
   - `html.elements.img.usemap.caseless_usemap`
@@ -2234,14 +2189,14 @@
   - [`html.elements.rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp)
   - [`html.elements.rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt)
   - `html.elements.script.type.module`
-  - [`html.elements.slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) +1
+  - [`html.elements.slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot)
   - [`html.elements.summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary)
   - `html.elements.textarea.autocomplete`
   - [`html.elements.wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr)
   - `http.data-url.html_files`
   - `http.headers.Access-Control-Expose-Headers.wildcard`
   - [`http.headers.Content-Security-Policy.base-uri`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri)
-  - [`http.headers.Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy) +1 +1 +1
+  - [`http.headers.Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy)
   - `http.headers.Set-Cookie.cookie_prefixes`
   - [`javascript.builtins.Array.@@species`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species)
   - [`javascript.builtins.Array.flat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
@@ -2249,9 +2204,9 @@
   - `javascript.builtins.Array.sort.stable_sorting`
   - `javascript.builtins.Array.toLocaleString.locales_parameter`
   - `javascript.builtins.Array.toLocaleString.options_parameter`
-  - [`javascript.builtins.AsyncGenerator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) +1 +1 +1
-  - [`javascript.builtins.AsyncGeneratorFunction`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction) +1
-  - [`javascript.builtins.AsyncIterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) +1
+  - [`javascript.builtins.AsyncGenerator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator)
+  - [`javascript.builtins.AsyncGeneratorFunction`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction)
+  - [`javascript.builtins.AsyncIterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
   - `javascript.builtins.Date.UTC.optional_monthIndex`
   - `javascript.builtins.Function.name.inferred_names`
   - [`javascript.builtins.JSON.json_superset`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON#JavaScript_and_JSON_differences)
@@ -2322,7 +2277,7 @@
   - [`svg.elements.feDisplacementMap.yChannelSelector`](https://developer.mozilla.org/docs/Web/SVG/Attribute/yChannelSelector)
   - [`svg.elements.feDistantLight.azimuth`](https://developer.mozilla.org/docs/Web/SVG/Attribute/azimuth)
   - [`svg.elements.feDistantLight.elevation`](https://developer.mozilla.org/docs/Web/SVG/Attribute/elevation)
-  - [`svg.elements.feDropShadow`](https://developer.mozilla.org/docs/Web/SVG/Element/feDropShadow) +1 +1 +1 +1
+  - [`svg.elements.feDropShadow`](https://developer.mozilla.org/docs/Web/SVG/Element/feDropShadow)
   - `svg.elements.feFlood.flood-opacity`
   - `svg.elements.feImage.preserveAspectRatio`
   - `svg.elements.feSpecularLighting.surfaceScale`
@@ -2416,15 +2371,11 @@
   - {'browser':'chrome','version':'78'}
   - {'browser':'firefox','version':'70'}
 ### These Features became stable across all major browsers:
-  - [`api.AuthenticatorAssertionResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse) +1 +1 +1
-  - [`api.AuthenticatorAttestationResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse) +1
-  - [`api.AuthenticatorResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse) +1
-  - [`api.Credential`](https://developer.mozilla.org/docs/Web/API/Credential) +1 +1
-  - [`api.CredentialsContainer`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer) +1
-  - `api.CredentialsContainer.create.publicKey_option` +1
-  - [`api.CredentialsContainer.create.publicKey_option.extensions.appidExclude`](https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appidexclude) +1
-  - `api.CredentialsContainer.get.publicKey_option` +1
-  - `api.CredentialsContainer.get.publicKey_option.extensions.appid`
+  - [`api.AuthenticatorAssertionResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse)
+  - [`api.AuthenticatorAttestationResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse)
+  - [`api.AuthenticatorResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse)
+  - [`api.Credential`](https://developer.mozilla.org/docs/Web/API/Credential)
+  - [`api.CredentialsContainer`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer)
   - [`api.Element.gotpointercapture_event`](https://developer.mozilla.org/docs/Web/API/Element/gotpointercapture_event)
   - [`api.Element.lostpointercapture_event`](https://developer.mozilla.org/docs/Web/API/HTMLElement/lostpointercapture_event)
   - [`api.Element.pointercancel_event`](https://developer.mozilla.org/docs/Web/API/Element/pointercancel_event)
@@ -2438,24 +2389,24 @@
   - [`api.Element.releasePointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/releasePointerCapture)
   - [`api.Element.setPointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture)
   - [`api.HTMLObjectElement.contentWindow`](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/contentWindow)
-  - [`api.MediaSource`](https://developer.mozilla.org/docs/Web/API/MediaSource) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaSource`](https://developer.mozilla.org/docs/Web/API/MediaSource)
   - [`api.Navigator.credentials`](https://developer.mozilla.org/docs/Web/API/Navigator/credentials)
   - [`api.Navigator.maxTouchPoints`](https://developer.mozilla.org/docs/Web/API/Navigator/maxTouchPoints)
-  - [`api.PointerEvent`](https://developer.mozilla.org/docs/Web/API/PointerEvent) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.PublicKeyCredential`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential) +1 +1 +1 +1
-  - [`api.SourceBuffer`](https://developer.mozilla.org/docs/Web/API/SourceBuffer) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.SourceBufferList`](https://developer.mozilla.org/docs/Web/API/SourceBufferList) +1 +1 +1
-  - [`api.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange) +1 +1 +1 +1 +1
+  - [`api.PointerEvent`](https://developer.mozilla.org/docs/Web/API/PointerEvent)
+  - [`api.PublicKeyCredential`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential)
+  - [`api.SourceBuffer`](https://developer.mozilla.org/docs/Web/API/SourceBuffer)
+  - [`api.SourceBufferList`](https://developer.mozilla.org/docs/Web/API/SourceBufferList)
+  - [`api.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange)
   - [`api.Window.afterprint_event`](https://developer.mozilla.org/docs/Web/API/Window/afterprint_event)
   - [`api.Window.beforeprint_event`](https://developer.mozilla.org/docs/Web/API/Window/beforeprint_event)
   - [`css.properties.line-break`](https://developer.mozilla.org/docs/Web/CSS/line-break)
   - `css.properties.position.sticky`
-  - [`css.properties.touch-action`](https://developer.mozilla.org/docs/Web/CSS/touch-action) +1 +1 +1 +1
+  - [`css.properties.touch-action`](https://developer.mozilla.org/docs/Web/CSS/touch-action)
   - `html.elements.a.download`
-  - [`http.headers.Set-Cookie.SameSite`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) +1
+  - [`http.headers.Set-Cookie.SameSite`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
   - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_hourCycle_parameter`
   - [`javascript.builtins.Intl.NumberFormat.formatToParts`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts)
-  - [`javascript.builtins.Intl.PluralRules`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) +1 +1 +1 +1
+  - [`javascript.builtins.Intl.PluralRules`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules)
 
 ## Sep 2019
 ### Browsers released:
@@ -2491,30 +2442,30 @@
 ### Browsers released:
   - {'browser':'chrome','version':'74'}
 ### These Features became stable across all major browsers:
-  - [`api.AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController) +1 +1 +1
+  - [`api.AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController)
   - [`api.DedicatedWorkerGlobalScope.name`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/name)
   - [`api.Event.returnValue`](https://developer.mozilla.org/docs/Web/API/Event/returnValue)
-  - [`api.HTMLDataListElement`](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement) +1
+  - [`api.HTMLDataListElement`](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement)
   - [`api.HTMLInputElement.list`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/list)
   - [`api.HTMLMediaElement.encrypted_event`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/encrypted_event)
   - [`api.HTMLMediaElement.mediaKeys`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys)
   - [`api.HTMLMediaElement.setMediaKeys`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys)
-  - [`api.IntersectionObserver`](https://developer.mozilla.org/docs/Web/API/IntersectionObserver) +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.IntersectionObserverEntry`](https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry) +1 +1 +1 +1 +1 +1 +1
-  - [`api.MediaEncryptedEvent`](https://developer.mozilla.org/docs/Web/API/MediaEncryptedEvent) +1 +1 +1
-  - [`api.MediaKeyMessageEvent`](https://developer.mozilla.org/docs/Web/API/MediaKeyMessageEvent) +1 +1 +1
-  - [`api.MediaKeySession`](https://developer.mozilla.org/docs/Web/API/MediaKeySession) +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.MediaKeyStatusMap`](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap) +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.MediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/MediaKeySystemAccess) +1 +1 +1
-  - [`api.MediaKeys`](https://developer.mozilla.org/docs/Web/API/MediaKeys) +1 +1
+  - [`api.IntersectionObserver`](https://developer.mozilla.org/docs/Web/API/IntersectionObserver)
+  - [`api.IntersectionObserverEntry`](https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry)
+  - [`api.MediaEncryptedEvent`](https://developer.mozilla.org/docs/Web/API/MediaEncryptedEvent)
+  - [`api.MediaKeyMessageEvent`](https://developer.mozilla.org/docs/Web/API/MediaKeyMessageEvent)
+  - [`api.MediaKeySession`](https://developer.mozilla.org/docs/Web/API/MediaKeySession)
+  - [`api.MediaKeyStatusMap`](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap)
+  - [`api.MediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/MediaKeySystemAccess)
+  - [`api.MediaKeys`](https://developer.mozilla.org/docs/Web/API/MediaKeys)
   - [`api.MouseEvent.getModifierState`](https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState)
   - [`api.Navigator.requestMediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/Navigator/requestMediaKeySystemAccess)
-  - [`api.RTCRtpReceiver.getContributingSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getContributingSources) +1
+  - [`api.RTCRtpReceiver.getContributingSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getContributingSources)
   - [`api.RTCRtpReceiver.getStats`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getStats)
   - [`api.RTCRtpSender.getStats`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getStats)
   - `api.Request.credentials.default_same-origin`
   - [`api.Request.signal`](https://developer.mozilla.org/docs/Web/API/Request/signal)
-  - [`api.VideoPlaybackQuality`](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality) +1 +1 +1
+  - [`api.VideoPlaybackQuality`](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality)
   - [`api.Window.event`](https://developer.mozilla.org/docs/Web/API/Window/event)
   - `api.Worker.Worker.options_name_parameter`
   - `css.properties.gap.grid_context.calc_values`
@@ -2539,17 +2490,15 @@
 
 ## Feb 2019
 ### These Features became stable across all major browsers:
-  - [`api.ByteLengthQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy) +1 +1 +1
-  - [`api.CountQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy) +1 +1 +1
-  - [`api.HTMLMarqueeElement`](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream) +1 +1 +1
+  - [`api.ByteLengthQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy)
+  - [`api.CountQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy)
+  - [`api.HTMLMarqueeElement`](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement)
+  - [`api.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream)
   - [`api.Response.body`](https://developer.mozilla.org/docs/Web/API/Response/body)
   - `api.Window.open.once_per_event`
-  - [`css.properties.break-after`](https://developer.mozilla.org/docs/Web/CSS/break-after) +1
-  - `css.properties.break-after.paged_context.page`
-  - [`css.properties.break-before`](https://developer.mozilla.org/docs/Web/CSS/break-before) +1
-  - `css.properties.break-before.paged_context.page`
-  - [`css.properties.break-inside`](https://developer.mozilla.org/docs/Web/CSS/break-inside) +1 +1
+  - [`css.properties.break-after`](https://developer.mozilla.org/docs/Web/CSS/break-after)
+  - [`css.properties.break-before`](https://developer.mozilla.org/docs/Web/CSS/break-before)
+  - [`css.properties.break-inside`](https://developer.mozilla.org/docs/Web/CSS/break-inside)
   - [`html.elements.marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee)
 
 ## Jan 2019
@@ -2609,11 +2558,11 @@
   - [`api.HTMLSelectElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/labels)
   - [`api.HTMLTextAreaElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/labels)
   - [`api.MediaDeviceInfo.toJSON`](https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON)
-  - [`api.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode) +1
+  - [`api.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode)
   - [`api.PerformanceResourceTiming.secureConnectionStart`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart)
   - [`api.PerformanceTiming.secureConnectionStart`](https://developer.mozilla.org/docs/Web/API/PerformanceTiming/secureConnectionStart)
   - [`api.RTCPeerConnection.getConfiguration`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getConfiguration)
-  - [`api.SecurityPolicyViolationEvent`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.SecurityPolicyViolationEvent`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent)
   - [`api.ServiceWorkerRegistration.updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache)
   - [`api.TextTrack.id`](https://developer.mozilla.org/docs/Web/API/TextTrack/id)
   - [`api.TextTrackList.change_event`](https://developer.mozilla.org/docs/Web/API/TextTrackList/change_event)
@@ -2644,7 +2593,7 @@
   - `api.CustomEvent.worker_support`
   - [`api.Event.srcElement`](https://developer.mozilla.org/docs/Web/API/Event/srcElement)
   - [`api.HTMLIFrameElement.allowFullscreen`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/allowFullscreen)
-  - [`api.RTCPeerConnectionIceEvent`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceEvent) +1 +1
+  - [`api.RTCPeerConnectionIceEvent`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceEvent)
   - `api.Request.Request.cross_origin_stripped`
   - [`css.at-rules.font-face.font-stretch`](https://developer.mozilla.org/docs/Web/CSS/@font-face/font-stretch)
   - `css.at-rules.font-face.src.format_variations`
@@ -2682,7 +2631,7 @@
   - `api.PerformanceEntry.worker_support`
   - `html.elements.script.nomodule`
   - [`javascript.builtins.Array.values`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values)
-  - [`javascript.statements.export`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export) +1
+  - [`javascript.statements.export`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export)
   - [`javascript.statements.import`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import)
 
 ## May 2018
@@ -2690,17 +2639,16 @@
   - {'browser':'chrome','version':'67'}
   - {'browser':'firefox','version':'60'}
 ### These Features became stable across all major browsers:
-  - [`api.AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal) +1 +1
-  - [`api.Cache`](https://developer.mozilla.org/docs/Web/API/Cache) +1 +1 +1 +1 +1 +1 +1 +1
-  - [`api.CacheStorage`](https://developer.mozilla.org/docs/Web/API/CacheStorage) +1 +1 +1 +1 +1 +1
+  - [`api.AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal)
+  - [`api.Cache`](https://developer.mozilla.org/docs/Web/API/Cache)
+  - [`api.CacheStorage`](https://developer.mozilla.org/docs/Web/API/CacheStorage)
   - [`api.CharacterData.after`](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
   - [`api.CharacterData.before`](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
   - [`api.CharacterData.nextElementSibling`](https://developer.mozilla.org/docs/Web/API/CharacterData/nextElementSibling)
   - [`api.CharacterData.previousElementSibling`](https://developer.mozilla.org/docs/Web/API/CharacterData/previousElementSibling)
   - [`api.CharacterData.replaceWith`](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
-  - [`api.Client`](https://developer.mozilla.org/docs/Web/API/Client) +1 +1 +1 +1 +1
-  - [`api.Clients`](https://developer.mozilla.org/docs/Web/API/Clients) +1 +1 +1
-  - `api.Clients.matchAll.options_includeUncontrolled_parameter` +1
+  - [`api.Client`](https://developer.mozilla.org/docs/Web/API/Client)
+  - [`api.Clients`](https://developer.mozilla.org/docs/Web/API/Clients)
   - [`api.ClipboardEvent.ClipboardEvent`](https://developer.mozilla.org/docs/Web/API/ClipboardEvent/ClipboardEvent)
   - [`api.DOMTokenList.remove_duplicates`](https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates)
   - [`api.DOMTokenList.replace`](https://developer.mozilla.org/docs/Web/API/DOMTokenList/replace)
@@ -2735,10 +2683,9 @@
   - [`api.Element.insertAdjacentText`](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText)
   - [`api.Element.prepend`](https://developer.mozilla.org/docs/Web/API/Element/prepend)
   - [`api.Element.replaceWith`](https://developer.mozilla.org/docs/Web/API/Element/replaceWith)
-  - [`api.ExtendableEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent) +1 +1
-  - `api.ExtendableEvent.waitUntil.async_waitUntil`
-  - [`api.ExtendableMessageEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableMessageEvent) +1 +1 +1 +1 +1 +1
-  - [`api.FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent) +1 +1 +1 +1
+  - [`api.ExtendableEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent)
+  - [`api.ExtendableMessageEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableMessageEvent)
+  - [`api.FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent)
   - [`api.File.webkitRelativePath`](https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath)
   - [`api.HTMLAnchorElement.origin`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/origin)
   - [`api.HTMLAnchorElement.ping`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/ping)
@@ -2768,7 +2715,7 @@
   - [`api.Navigator.serviceWorker`](https://developer.mozilla.org/docs/Web/API/Navigator/serviceWorker)
   - [`api.NodeIterator.pointerBeforeReferenceNode`](https://developer.mozilla.org/docs/Web/API/NodeIterator/pointerBeforeReferenceNode)
   - [`api.NodeIterator.referenceNode`](https://developer.mozilla.org/docs/Web/API/NodeIterator/referenceNode)
-  - [`api.OES_vertex_array_object`](https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object) +1 +1 +1 +1
+  - [`api.OES_vertex_array_object`](https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object)
   - [`api.PerformanceResourceTiming.nextHopProtocol`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol)
   - [`api.Range.comparePoint`](https://developer.mozilla.org/docs/Web/API/Range/comparePoint)
   - [`api.Range.intersectsNode`](https://developer.mozilla.org/docs/Web/API/Range/intersectsNode)
@@ -2776,25 +2723,22 @@
   - [`api.SVGElement.dataset`](https://developer.mozilla.org/docs/Web/API/SVGElement/dataset)
   - `api.SVGElement.focus`
   - `api.SVGElement.tabIndex`
-  - [`api.ServiceWorker`](https://developer.mozilla.org/docs/Web/API/ServiceWorker) +1 +1 +1 +1 +1
-  - [`api.ServiceWorkerContainer`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer) +1 +1 +1 +1 +1 +1 +1
-  - [`api.ServiceWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope) +1 +1 +1 +1 +1 +1 +1
-  - [`api.ServiceWorkerRegistration`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration) +1 +1 +1 +1 +1 +1 +1
+  - [`api.ServiceWorker`](https://developer.mozilla.org/docs/Web/API/ServiceWorker)
+  - [`api.ServiceWorkerContainer`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer)
+  - [`api.ServiceWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope)
+  - [`api.ServiceWorkerRegistration`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration)
   - [`api.StorageEvent.StorageEvent`](https://developer.mozilla.org/docs/Web/API/StorageEvent/StorageEvent)
   - [`api.URL.searchParams`](https://developer.mozilla.org/docs/Web/API/URL/searchParams)
   - [`api.URL.toString`](https://developer.mozilla.org/docs/Web/API/URL/toString)
-  - [`api.URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) +1 +1
-  - `api.URLSearchParams.URLSearchParams.USVString`
-  - `api.URLSearchParams.URLSearchParams.record`
-  - `api.URLSearchParams.URLSearchParams.sequence` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
   - [`api.ValidityState.tooShort`](https://developer.mozilla.org/docs/Web/API/ValidityState/tooShort)
-  - [`api.WEBGL_lose_context`](https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context) +1 +1
+  - [`api.WEBGL_lose_context`](https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context)
   - [`api.WebGLVertexArrayObjectOES`](https://developer.mozilla.org/docs/Web/API/WebGLVertexArrayObjectOES)
-  - [`api.WindowClient`](https://developer.mozilla.org/docs/Web/API/WindowClient) +1 +1 +1
+  - [`api.WindowClient`](https://developer.mozilla.org/docs/Web/API/WindowClient)
   - [`api.WorkerGlobalScope.navigator`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/navigator)
-  - [`api.caches`](https://developer.mozilla.org/docs/Web/API/caches) +1
+  - [`api.caches`](https://developer.mozilla.org/docs/Web/API/caches)
   - `api.fetch.init_signal_parameter`
-  - [`api.isSecureContext`](https://developer.mozilla.org/docs/Web/API/isSecureContext) +1
+  - [`api.isSecureContext`](https://developer.mozilla.org/docs/Web/API/isSecureContext)
   - `css.properties.gap.grid_context.percentage_values`
   - `css.properties.transform-origin.svg_elements`
   - `html.elements.a.ping`
@@ -2845,7 +2789,7 @@
   - [`api.Document.vlinkColor`](https://developer.mozilla.org/docs/Web/API/Document/vlinkColor)
   - [`api.Document.writeln`](https://developer.mozilla.org/docs/Web/API/Document/writeln)
   - [`api.PerformanceResourceTiming.workerStart`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart)
-  - [`api.RTCRtpSender`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender) +1
+  - [`api.RTCRtpSender`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender)
   - [`api.Request.cache`](https://developer.mozilla.org/docs/Web/API/Request/cache)
   - [`http.headers.Content-Security-Policy.frame-ancestors`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
   - [`http.headers.X-Content-Type-Options`](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Content-Type-Options)

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,119 @@
 
+
+# 2024
+
+
+
+## Jun 2024
+
+## May 2024
+### Browsers released:
+  - {'browser':'firefox','version':'126'}
+### These Features became stable across all major browsers:
+  - `css.properties.writing-mode.vertical_oriented_form_controls`
+  - `html.elements.input.type_range.vertical_orientation`
+
+## Apr 2024
+### Browsers released:
+  - {'browser':'chrome','version':'124'}
+  - {'browser':'edge','version':'124'}
+  - {'browser':'firefox','version':'125'}
+### These Features became stable across all major browsers:
+  - [`api.AbortSignal.any_static`](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static)
+  - [`api.DOMMatrixReadOnly.scaleNonUniform`](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/scaleNonUniform)
+  - [`api.Element.ariaDescription`](https://developer.mozilla.org/docs/Web/API/Element/ariaDescription)
+  - [`api.Element.checkVisibility`](https://developer.mozilla.org/docs/Web/API/Element/checkVisibility)
+  - [`api.Navigator.wakeLock`](https://developer.mozilla.org/docs/Web/API/Navigator/wakeLock)
+  - `api.SVGFESpecularLightingElement.kernelUnitLengthX`
+  - `api.SVGFESpecularLightingElement.kernelUnitLengthY`
+  - [`api.WakeLock`](https://developer.mozilla.org/docs/Web/API/WakeLock) +1
+  - [`api.WakeLockSentinel`](https://developer.mozilla.org/docs/Web/API/WakeLockSentinel) +1 +1 +1 +1
+  - [`css.properties.paint-order`](https://developer.mozilla.org/docs/Web/CSS/paint-order)
+  - `css.properties.text-decoration-thickness.percentage`
+  - [`css.properties.text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) +1 +1
+  - `css.selectors.backdrop.inherit_from_originating_element`
+  - [`http.headers.Permissions-Policy.screen-wake-lock`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/screen-wake-lock)
+  - [`javascript.builtins.ArrayBuffer.detached`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached)
+  - [`javascript.builtins.ArrayBuffer.transfer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer)
+  - [`javascript.builtins.ArrayBuffer.transferToFixedLength`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength)
+  - [`javascript.builtins.Map.groupBy`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy)
+  - [`javascript.builtins.Object.groupBy`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy)
+  - [`javascript.builtins.Promise.withResolvers`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers)
+  - `svg.elements.feSpecularLighting.kernelUnitLength`
+  - `webassembly.extended-constant-expressions`
+
+## Mar 2024
+### Browsers released:
+  - {'browser':'chrome','version':'123'}
+  - {'browser':'edge','version':'123'}
+  - {'browser':'firefox','version':'124'}
+  - {'browser':'safari','version':'17.4'}
+  - {'browser':'safari_ios','version':'17.4'}
+### These Features became stable across all major browsers:
+  - `api.HTMLTemplateElement.shadowRootMode`
+  - `html.elements.template.shadowrootmode`
+
+## Feb 2024
+### Browsers released:
+  - {'browser':'chrome','version':'122'}
+  - {'browser':'edge','version':'122'}
+  - {'browser':'firefox','version':'123'}
+### These Features became stable across all major browsers:
+  - [`api.HTMLVideoElement.disablePictureInPicture`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/disablePictureInPicture)
+  - `css.properties.offset-path.ray`
+  - `css.properties.offset-path.url`
+  - [`css.properties.offset-position`](https://developer.mozilla.org/docs/Web/CSS/offset-position) +1 +1
+  - [`css.types.basic-shape.rect`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/rect)
+  - [`css.types.basic-shape.xywh`](https://developer.mozilla.org/docs/Web/CSS/basic-shape/xywh)
+  - [`css.types.ray`](https://developer.mozilla.org/docs/Web/CSS/ray) +1 +1
+  - `html.elements.video.disablepictureinpicture`
+  - [`javascript.builtins.Array.fromAsync`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync)
+
+## Jan 2024
+### Browsers released:
+  - {'browser':'chrome','version':'121'}
+  - {'browser':'edge','version':'121'}
+  - {'browser':'firefox','version':'122'}
+  - {'browser':'safari','version':'17.3'}
+  - {'browser':'safari_ios','version':'17.3'}
+### These Features became stable across all major browsers:
+  - [`api.CanvasRenderingContext2D.reset`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/reset)
+  - [`api.FontFaceSet.check`](https://developer.mozilla.org/docs/Web/API/FontFaceSet/check)
+  - [`api.HTMLIFrameElement.loading`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/loading)
+  - `api.HTMLLinkElement.imageSizes`
+  - `api.HTMLLinkElement.imageSrcset`
+  - [`api.HTMLMediaElement.preservesPitch`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch)
+  - [`api.OffscreenCanvasRenderingContext2D.reset`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset)
+  - [`api.SVGImageElement.crossOrigin`](https://developer.mozilla.org/docs/Web/API/SVGImageElement/crossorigin)
+  - [`api.URL.canParse_static`](https://developer.mozilla.org/docs/Web/API/URL/canParse_static)
+  - [`css.at-rules.media.scripting`](https://developer.mozilla.org/docs/Web/CSS/@media/scripting)
+  - `css.properties.background-clip.text`
+  - [`css.properties.counter-set`](https://developer.mozilla.org/docs/Web/CSS/counter-set) +1 +1
+  - [`css.properties.mask-clip`](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
+  - [`css.properties.mask-composite`](https://developer.mozilla.org/docs/Web/CSS/mask-composite) +1 +1 +1 +1
+  - [`css.properties.mask-image`](https://developer.mozilla.org/docs/Web/CSS/mask-image)
+  - [`css.properties.mask-mode`](https://developer.mozilla.org/docs/Web/CSS/mask-mode) +1 +1 +1
+  - [`css.properties.mask-origin`](https://developer.mozilla.org/docs/Web/CSS/mask-origin)
+  - [`css.properties.mask-position`](https://developer.mozilla.org/docs/Web/CSS/mask-position)
+  - [`css.properties.mask-repeat`](https://developer.mozilla.org/docs/Web/CSS/mask-repeat)
+  - [`css.properties.mask-size`](https://developer.mozilla.org/docs/Web/CSS/mask-size)
+  - [`css.selectors.dir`](https://developer.mozilla.org/docs/Web/CSS/:dir)
+  - [`css.selectors.has`](https://developer.mozilla.org/docs/Web/CSS/:has)
+  - [`css.selectors.nesting`](https://developer.mozilla.org/docs/Web/CSS/Nesting_selector)
+  - `css.types.easing-function.linear-function`
+  - [`css.types.exp`](https://developer.mozilla.org/docs/Web/CSS/exp)
+  - [`css.types.hypot`](https://developer.mozilla.org/docs/Web/CSS/hypot)
+  - `css.types.length.cap`
+  - [`css.types.log`](https://developer.mozilla.org/docs/Web/CSS/log)
+  - [`css.types.pow`](https://developer.mozilla.org/docs/Web/CSS/pow)
+  - [`css.types.sqrt`](https://developer.mozilla.org/docs/Web/CSS/sqrt)
+  - `html.elements.iframe.loading`
+  - `html.elements.link.imagesizes`
+  - `html.elements.link.imagesrcset`
+  - [`svg.elements.image.crossorigin`](https://developer.mozilla.org/docs/Web/SVG/Attribute/crossorigin)
+
+
+
 # 2023
 
 
@@ -8,35 +123,171 @@
   - {'browser':'chrome','version':'120'}
   - {'browser':'edge','version':'120'}
   - {'browser':'firefox','version':'121'}
+  - {'browser':'safari','version':'17.2'}
+  - {'browser':'safari_ios','version':'17.2'}
 ### These Features became stable across all major browsers:
+  - `api.BeforeUnloadEvent.returnValue`
+  - [`api.Navigator.userActivation`](https://developer.mozilla.org/docs/Web/API/Navigator/userActivation)
+  - `api.PublicKeyCredential.authenticatorAttachment`
+  - [`api.ToggleEvent`](https://developer.mozilla.org/docs/Web/API/ToggleEvent) +1 +1 +1
+  - [`api.UserActivation`](https://developer.mozilla.org/docs/Web/API/UserActivation) +1 +1
+  - `css.properties.clip-path.fill-box`
+  - `css.properties.clip-path.stroke-box`
   - [`css.selectors.user-invalid`](https://developer.mozilla.org/docs/Web/CSS/:user-invalid)
   - [`css.selectors.user-valid`](https://developer.mozilla.org/docs/Web/CSS/:user-valid)
+  - `css.types.length.lh`
+  - `css.types.length.rlh`
 
 ## Nov 2023
 ### Browsers released:
   - {'browser':'edge','version':'119'}
   - {'browser':'firefox','version':'120'}
 ### These Features became stable across all major browsers:
+  - [`api.AuthenticatorAttestationResponse.getAuthenticatorData`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getAuthenticatorData)
+  - [`api.AuthenticatorAttestationResponse.getPublicKey`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getPublicKey)
+  - [`api.AuthenticatorAttestationResponse.getPublicKeyAlgorithm`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getPublicKeyAlgorithm)
+  - [`api.AuthenticatorAttestationResponse.getTransports`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getTransports)
+  - [`api.Document.hasStorageAccess`](https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess)
+  - [`api.Document.requestStorageAccess`](https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess)
+  - [`api.Element.ariaAtomic`](https://developer.mozilla.org/docs/Web/API/Element/ariaAtomic)
+  - [`api.Element.ariaAutoComplete`](https://developer.mozilla.org/docs/Web/API/Element/ariaAutoComplete)
+  - [`api.Element.ariaBusy`](https://developer.mozilla.org/docs/Web/API/Element/ariaBusy)
+  - [`api.Element.ariaChecked`](https://developer.mozilla.org/docs/Web/API/Element/ariaChecked)
+  - [`api.Element.ariaColCount`](https://developer.mozilla.org/docs/Web/API/Element/ariaColCount)
+  - [`api.Element.ariaColIndex`](https://developer.mozilla.org/docs/Web/API/Element/ariaColIndex)
+  - [`api.Element.ariaColSpan`](https://developer.mozilla.org/docs/Web/API/Element/ariaColSpan)
+  - [`api.Element.ariaCurrent`](https://developer.mozilla.org/docs/Web/API/Element/ariaCurrent)
+  - [`api.Element.ariaDisabled`](https://developer.mozilla.org/docs/Web/API/Element/ariaDisabled)
+  - [`api.Element.ariaExpanded`](https://developer.mozilla.org/docs/Web/API/Element/ariaExpanded)
+  - [`api.Element.ariaHasPopup`](https://developer.mozilla.org/docs/Web/API/Element/ariaHasPopup)
+  - [`api.Element.ariaHidden`](https://developer.mozilla.org/docs/Web/API/Element/ariaHidden)
+  - `api.Element.ariaInvalid`
+  - [`api.Element.ariaKeyShortcuts`](https://developer.mozilla.org/docs/Web/API/Element/ariaKeyShortcuts)
+  - [`api.Element.ariaLabel`](https://developer.mozilla.org/docs/Web/API/Element/ariaLabel)
+  - [`api.Element.ariaLevel`](https://developer.mozilla.org/docs/Web/API/Element/ariaLevel)
+  - [`api.Element.ariaLive`](https://developer.mozilla.org/docs/Web/API/Element/ariaLive)
+  - [`api.Element.ariaModal`](https://developer.mozilla.org/docs/Web/API/Element/ariaModal)
+  - [`api.Element.ariaMultiLine`](https://developer.mozilla.org/docs/Web/API/Element/ariaMultiLine)
+  - [`api.Element.ariaMultiSelectable`](https://developer.mozilla.org/docs/Web/API/Element/ariaMultiSelectable)
+  - [`api.Element.ariaOrientation`](https://developer.mozilla.org/docs/Web/API/Element/ariaOrientation)
+  - [`api.Element.ariaPlaceholder`](https://developer.mozilla.org/docs/Web/API/Element/ariaPlaceholder)
+  - [`api.Element.ariaPosInSet`](https://developer.mozilla.org/docs/Web/API/Element/ariaPosInSet)
+  - [`api.Element.ariaPressed`](https://developer.mozilla.org/docs/Web/API/Element/ariaPressed)
+  - [`api.Element.ariaReadOnly`](https://developer.mozilla.org/docs/Web/API/Element/ariaReadOnly)
+  - [`api.Element.ariaRelevant`](https://developer.mozilla.org/docs/Web/API/Element/ariaRelevant)
+  - [`api.Element.ariaRequired`](https://developer.mozilla.org/docs/Web/API/Element/ariaRequired)
+  - [`api.Element.ariaRoleDescription`](https://developer.mozilla.org/docs/Web/API/Element/ariaRoleDescription)
+  - [`api.Element.ariaRowCount`](https://developer.mozilla.org/docs/Web/API/Element/ariaRowCount)
+  - [`api.Element.ariaRowIndex`](https://developer.mozilla.org/docs/Web/API/Element/ariaRowIndex)
+  - [`api.Element.ariaRowSpan`](https://developer.mozilla.org/docs/Web/API/Element/ariaRowSpan)
+  - [`api.Element.ariaSelected`](https://developer.mozilla.org/docs/Web/API/Element/ariaSelected)
+  - [`api.Element.ariaSetSize`](https://developer.mozilla.org/docs/Web/API/Element/ariaSetSize)
+  - [`api.Element.ariaSort`](https://developer.mozilla.org/docs/Web/API/Element/ariaSort)
+  - [`api.Element.ariaValueMax`](https://developer.mozilla.org/docs/Web/API/Element/ariaValueMax)
+  - [`api.Element.ariaValueMin`](https://developer.mozilla.org/docs/Web/API/Element/ariaValueMin)
+  - [`api.Element.ariaValueNow`](https://developer.mozilla.org/docs/Web/API/Element/ariaValueNow)
+  - [`api.Element.ariaValueText`](https://developer.mozilla.org/docs/Web/API/Element/ariaValueText)
+  - `api.Element.role`
+  - [`api.ElementInternals.ariaAtomic`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaAtomic)
+  - [`api.ElementInternals.ariaAutoComplete`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaAutoComplete)
+  - [`api.ElementInternals.ariaBusy`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaBusy)
+  - [`api.ElementInternals.ariaChecked`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaChecked)
+  - [`api.ElementInternals.ariaColCount`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColCount)
+  - [`api.ElementInternals.ariaColIndex`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColIndex)
+  - [`api.ElementInternals.ariaColSpan`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColSpan)
+  - [`api.ElementInternals.ariaCurrent`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaCurrent)
+  - [`api.ElementInternals.ariaDisabled`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaDisabled)
+  - [`api.ElementInternals.ariaExpanded`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaExpanded)
+  - [`api.ElementInternals.ariaHasPopup`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaHasPopup)
+  - [`api.ElementInternals.ariaHidden`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaHidden)
+  - `api.ElementInternals.ariaInvalid`
+  - [`api.ElementInternals.ariaKeyShortcuts`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaKeyShortcuts)
+  - [`api.ElementInternals.ariaLabel`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLabel)
+  - [`api.ElementInternals.ariaLevel`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLevel)
+  - [`api.ElementInternals.ariaLive`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLive)
+  - [`api.ElementInternals.ariaModal`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaModal)
+  - [`api.ElementInternals.ariaMultiLine`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaMultiLine)
+  - [`api.ElementInternals.ariaMultiSelectable`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaMultiSelectable)
+  - [`api.ElementInternals.ariaOrientation`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaOrientation)
+  - [`api.ElementInternals.ariaPlaceholder`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPlaceholder)
+  - [`api.ElementInternals.ariaPosInSet`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPosInSet)
+  - [`api.ElementInternals.ariaPressed`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPressed)
+  - [`api.ElementInternals.ariaReadOnly`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaReadOnly)
+  - [`api.ElementInternals.ariaRelevant`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRelevant)
+  - [`api.ElementInternals.ariaRequired`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRequired)
+  - [`api.ElementInternals.ariaRoleDescription`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRoleDescription)
+  - [`api.ElementInternals.ariaRowCount`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowCount)
+  - [`api.ElementInternals.ariaRowIndex`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowIndex)
+  - [`api.ElementInternals.ariaRowSpan`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowSpan)
+  - [`api.ElementInternals.ariaSelected`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSelected)
+  - [`api.ElementInternals.ariaSetSize`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSetSize)
+  - [`api.ElementInternals.ariaSort`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSort)
+  - [`api.ElementInternals.ariaValueMax`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueMax)
+  - [`api.ElementInternals.ariaValueMin`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueMin)
+  - [`api.ElementInternals.ariaValueNow`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueNow)
+  - [`api.ElementInternals.ariaValueText`](https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueText)
+  - [`api.ElementInternals.role`](https://developer.mozilla.org/docs/Web/API/ElementInternals/role)
+  - [`api.TextMetrics.alphabeticBaseline`](https://developer.mozilla.org/docs/Web/API/TextMetrics/alphabeticBaseline)
+  - [`api.TextMetrics.hangingBaseline`](https://developer.mozilla.org/docs/Web/API/TextMetrics/hangingBaseline)
+  - [`api.TextMetrics.ideographicBaseline`](https://developer.mozilla.org/docs/Web/API/TextMetrics/ideographicBaseline)
+  - `css.properties.clear.inline-end`
+  - `css.properties.clear.inline-start`
+  - `css.properties.float.inline-end`
+  - `css.properties.float.inline-start`
+  - `css.properties.resize.block`
+  - `css.properties.resize.inline`
+  - `css.properties.transform-box.border-box`
   - [`html.elements.search`](https://developer.mozilla.org/docs/Web/HTML/Element/search)
+  - [`javascript.builtins.String.isWellFormed`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/isWellFormed)
+  - [`javascript.builtins.String.toWellFormed`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed)
+  - [`webextensions.api.action.openPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup)
 
 ## Oct 2023
 ### Browsers released:
   - {'browser':'chrome','version':'119'}
   - {'browser':'edge','version':'118'}
   - {'browser':'firefox','version':'119'}
+  - {'browser':'safari','version':'17.1'}
+  - {'browser':'safari_ios','version':'17.1'}
 ### These Features became stable across all major browsers:
-  - [`api.CSSCounterStyleRule`](https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule)
-  - [`api.DeviceMotionEvent`](https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent)
-  - [`api.DeviceOrientationEvent`](https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent)
-  - [`css.at-rules.counter-style`](https://developer.mozilla.org/docs/Web/CSS/@counter-style)
-  - [`css.properties.contain-intrinsic-block-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size)
-  - [`css.properties.contain-intrinsic-height`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height)
-  - [`css.properties.contain-intrinsic-inline-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size)
-  - [`css.properties.contain-intrinsic-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size)
-  - [`css.properties.contain-intrinsic-width`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width)
+  - [`api.CSSContainerRule.containerName`](https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerName)
+  - [`api.CSSContainerRule.containerQuery`](https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerQuery)
+  - [`api.CSSCounterStyleRule`](https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - `api.CanvasRenderingContext2D.drawImage.SVGImageElement_source_image`
+  - [`api.CredentialsContainer.preventSilentAccess`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess)
+  - [`api.CustomElementRegistry.getName`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/getName)
+  - [`api.DeviceMotionEvent`](https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent) +1 +1 +1 +1
+  - [`api.DeviceOrientationEvent`](https://developer.mozilla.org/docs/Web/API/DeviceOrientationEvent) +1 +1 +1
+  - [`api.Headers.getSetCookie`](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie)
+  - [`api.Response.json_static`](https://developer.mozilla.org/docs/Web/API/Response/json_static)
+  - [`api.Selection.removeRange`](https://developer.mozilla.org/docs/Web/API/Selection/removeRange)
+  - [`api.StorageManager.estimate`](https://developer.mozilla.org/docs/Web/API/StorageManager/estimate)
+  - [`api.URLSearchParams.size`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/size)
+  - [`api.Window.devicemotion_event`](https://developer.mozilla.org/docs/Web/API/Window/devicemotion_event)
+  - [`api.Window.deviceorientation_event`](https://developer.mozilla.org/docs/Web/API/Window/deviceorientation_event)
+  - [`css.at-rules.counter-style`](https://developer.mozilla.org/docs/Web/CSS/@counter-style) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.at-rules.font-face.size-adjust`](https://developer.mozilla.org/docs/Web/CSS/@font-face/size-adjust)
+  - [`css.at-rules.media.overflow-block`](https://developer.mozilla.org/docs/Web/CSS/@media/overflow-block)
+  - [`css.at-rules.media.overflow-inline`](https://developer.mozilla.org/docs/Web/CSS/@media/overflow-inline)
+  - [`css.at-rules.media.update`](https://developer.mozilla.org/docs/Web/CSS/@media/update-frequency)
+  - `css.at-rules.supports.font-format`
+  - `css.at-rules.supports.font-tech`
+  - [`css.properties.contain-intrinsic-block-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size) +1
+  - [`css.properties.contain-intrinsic-height`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height) +1
+  - [`css.properties.contain-intrinsic-inline-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size) +1
+  - [`css.properties.contain-intrinsic-size`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size) +1 +1
+  - [`css.properties.contain-intrinsic-width`](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width) +1
   - [`css.properties.font-variant-position`](https://developer.mozilla.org/docs/Web/CSS/font-variant-position)
+  - [`css.properties.grid-template-columns.subgrid`](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
+  - [`css.properties.grid-template-rows.subgrid`](https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
   - [`css.properties.hyphenate-character`](https://developer.mozilla.org/docs/Web/CSS/hyphenate-character)
   - [`css.properties.hyphens`](https://developer.mozilla.org/docs/Web/CSS/hyphens)
+  - `css.properties.list-style-type.ethiopic-halehame`
+  - `css.properties.list-style-type.ethiopic-halehame-am`
+  - [`javascript.builtins.RegExp.unicodeSets`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets)
+  - `mathml.elements.mtd.columnspan`
+  - `mathml.elements.mtd.rowspan`
+  - `webextensions.api.scripting.executeScript.InjectionResult` +1 +1
 
 ## Sep 2023
 ### Browsers released:
@@ -46,10 +297,19 @@
   - {'browser':'safari','version':'17'}
   - {'browser':'safari_ios','version':'17'}
 ### These Features became stable across all major browsers:
-  - [`api.RTCEncodedAudioFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame)
-  - [`api.RTCEncodedVideoFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame)
+  - [`api.CSSStyleRule.cssRules`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/cssRules)
+  - [`api.CSSStyleRule.deleteRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/deleteRule)
+  - [`api.CSSStyleRule.insertRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/insertRule)
+  - [`api.CanvasRenderingContext2D.getContextAttributes`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getContextAttributes)
+  - [`api.RTCEncodedAudioFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame) +1 +1 +1
+  - [`api.RTCEncodedVideoFrame`](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame) +1 +1 +1 +1
   - [`css.properties.math-style`](https://developer.mozilla.org/docs/Web/CSS/math-style)
-  - [`css.selectors.nesting`](https://developer.mozilla.org/docs/Web/CSS/Nesting_selectors)
+  - [`css.properties.offset-anchor`](https://developer.mozilla.org/docs/Web/CSS/offset-anchor) +1
+  - `css.types.color.lab.mixed_type_parameters`
+  - `css.types.color.lch.mixed_type_parameters`
+  - `css.types.color.oklab.mixed_type_parameters`
+  - `css.types.color.oklch.mixed_type_parameters`
+  - `http.headers.Range.cors_safe`
 
 ## Aug 2023
 ### Browsers released:
@@ -57,8 +317,33 @@
   - {'browser':'edge','version':'116'}
   - {'browser':'firefox','version':'117'}
 ### These Features became stable across all major browsers:
+  - `api.HTMLInputElement.dirName`
+  - `api.HTMLTextAreaElement.dirName`
+  - [`api.MediaDevices.enumerateDevices`](https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices)
+  - [`api.TextMetrics.fontBoundingBoxAscent`](https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxAscent)
+  - [`api.TextMetrics.fontBoundingBoxDescent`](https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxDescent)
   - [`css.properties.animation-composition`](https://developer.mozilla.org/docs/Web/CSS/animation-composition)
+  - `css.properties.display.multi-keyword_values`
   - [`css.selectors.first`](https://developer.mozilla.org/docs/Web/CSS/:first)
+  - [`html.elements.input.dirname`](https://developer.mozilla.org/docs/Web/HTML/Element/input#dirname)
+  - `html.elements.textarea.dirname`
+  - [`javascript.builtins.Array.toReversed`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed)
+  - [`javascript.builtins.Array.toSorted`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted)
+  - [`javascript.builtins.Array.toSpliced`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced)
+  - [`javascript.builtins.Array.with`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/with)
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_roundingIncrement_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_roundingMode_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_roundingPriority_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_signDisplay_parameter.negative`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_trailingZeroDisplay_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_useGrouping_parameter.string_values`
+  - `javascript.builtins.Intl.NumberFormat.format.number_parameter-string_decimal`
+  - [`javascript.builtins.Intl.NumberFormat.formatRange`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatRange)
+  - [`javascript.builtins.Intl.NumberFormat.formatRangeToParts`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatRangeToParts)
+  - [`javascript.builtins.Intl.PluralRules.selectRange`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/selectRange)
+  - [`javascript.builtins.TypedArray.toReversed`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed)
+  - [`javascript.builtins.TypedArray.toSorted`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted)
+  - [`javascript.builtins.TypedArray.with`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with)
   - [`webextensions.api.runtime.setUninstallURL`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL)
   - [`webextensions.api.storage.session`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/session)
 
@@ -70,24 +355,63 @@
   - {'browser':'safari','version':'16.6'}
   - {'browser':'safari_ios','version':'16.6'}
 ### These Features became stable across all major browsers:
+  - `api.SharedWorker.SharedWorker.ecmascript_modules`
+  - `api.Worker.Worker.ecmascript_modules`
+  - `api.Worklet.ecmascript_modules`
   - [`css.properties.-webkit-text-security`](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-security)
+  - `css.types.calc-constant.NaN`
+  - `css.types.calc-constant.infinity`
+  - `javascript.operators.import.worker_support`
+  - `javascript.statements.import.service_worker_support`
+  - `javascript.statements.import.worker_support`
 
 ## Jun 2023
 ### Browsers released:
   - {'browser':'edge','version':'114'}
   - {'browser':'firefox','version':'114'}
 ### These Features became stable across all major browsers:
-  - [`api.CompressionStream`](https://developer.mozilla.org/docs/Web/API/CompressionStream)
-  - [`api.DecompressionStream`](https://developer.mozilla.org/docs/Web/API/DecompressionStream)
-  - [`api.RTCSctpTransport`](https://developer.mozilla.org/docs/Web/API/RTCSctpTransport)
+  - [`api.CompressionStream`](https://developer.mozilla.org/docs/Web/API/CompressionStream) +1
+  - `api.CompressionStream.CompressionStream.deflate`
+  - `api.CompressionStream.CompressionStream.deflate-raw`
+  - `api.CompressionStream.CompressionStream.gzip` +1 +1
+  - [`api.DecompressionStream`](https://developer.mozilla.org/docs/Web/API/DecompressionStream) +1
+  - `api.DecompressionStream.DecompressionStream.deflate`
+  - `api.DecompressionStream.DecompressionStream.deflate-raw`
+  - `api.DecompressionStream.DecompressionStream.gzip` +1 +1
+  - `api.HTMLInputElement.cancel_event`
+  - [`api.RTCPeerConnection.connectionState`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/connectionState)
+  - [`api.RTCPeerConnection.connectionstatechange_event`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/connectionstatechange_event)
+  - [`api.RTCPeerConnection.sctp`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/sctp)
+  - [`api.RTCRtpReceiver.getCapabilities_static`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getCapabilities_static)
+  - [`api.RTCRtpSender.getCapabilities_static`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getCapabilities_static)
+  - [`api.RTCRtpSender.setStreams`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/setStreams)
+  - [`api.RTCSctpTransport`](https://developer.mozilla.org/docs/Web/API/RTCSctpTransport) +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_media-source`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_source) +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_peer-connection`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats) +1 +1 +1 +1 +1
+  - [`css.properties.background-image.image-set`](https://developer.mozilla.org/docs/Web/CSS/image-set())
+  - [`css.properties.content.gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient)
+  - `css.selectors.nth-child.of_syntax`
+  - `css.selectors.nth-last-child.of_syntax`
+  - [`css.types.color.color`](https://developer.mozilla.org/docs/Web/CSS/color_value/color) +1
+  - [`css.types.color.color-mix`](https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix)
+  - [`css.types.color.lab`](https://developer.mozilla.org/docs/Web/CSS/color_value/lab)
+  - [`css.types.color.lch`](https://developer.mozilla.org/docs/Web/CSS/color_value/lch)
+  - [`css.types.color.oklab`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklab)
+  - [`css.types.color.oklch`](https://developer.mozilla.org/docs/Web/CSS/color_value/oklch)
+  - [`css.types.image.image-set`](https://developer.mozilla.org/docs/Web/CSS/image/image-set)
   - [`webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES)
+  - [`webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_ENABLED_STATIC_RULESETS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_ENABLED_STATIC_RULESETS)
   - [`webextensions.api.declarativeNetRequest.MAX_NUMBER_OF_STATIC_RULESETS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/MAX_NUMBER_OF_STATIC_RULESETS)
   - [`webextensions.api.declarativeNetRequest.Redirect`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Redirect)
-  - [`webextensions.api.declarativeNetRequest.ResourceType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ResourceType)
+  - [`webextensions.api.declarativeNetRequest.ResourceType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/ResourceType) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
   - [`webextensions.api.declarativeNetRequest.Rule`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/Rule)
-  - [`webextensions.api.declarativeNetRequest.RuleAction`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleAction)
-  - [`webextensions.api.declarativeNetRequest.RuleCondition`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition)
-  - [`webextensions.api.declarativeNetRequest.URLTransform`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/URLTransform)
+  - [`webextensions.api.declarativeNetRequest.RuleAction`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleAction) +1
+  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.header`
+  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.operation`
+  - `webextensions.api.declarativeNetRequest.RuleAction.requestHeaders.value`
+  - [`webextensions.api.declarativeNetRequest.RuleCondition`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition) +1 +1 +1
+  - [`webextensions.api.declarativeNetRequest.URLTransform`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/URLTransform) +1
+  - `webextensions.api.declarativeNetRequest.URLTransform.queryTransform.addOrReplaceParams` +1
   - [`webextensions.api.declarativeNetRequest.getDynamicRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getDynamicRules)
   - [`webextensions.api.declarativeNetRequest.getEnabledRulesets`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getEnabledRulesets)
   - [`webextensions.api.declarativeNetRequest.getSessionRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getSessionRules)
@@ -95,7 +419,14 @@
   - [`webextensions.api.declarativeNetRequest.updateDynamicRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateDynamicRules)
   - [`webextensions.api.declarativeNetRequest.updateEnabledRulesets`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateEnabledRulesets)
   - [`webextensions.api.declarativeNetRequest.updateSessionRules`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateSessionRules)
-  - [`webextensions.manifest.declarative_net_request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request)
+  - [`webextensions.manifest.declarative_net_request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/declarative_net_request) +1
+  - `webextensions.manifest.declarative_net_request.rule_resources.enabled`
+  - `webextensions.manifest.declarative_net_request.rule_resources.id`
+  - `webextensions.manifest.declarative_net_request.rule_resources.path`
+  - `webextensions.manifest.optional_permissions.declarativeNetRequestFeedback`
+  - `webextensions.manifest.permissions.declarativeNetRequest`
+  - `webextensions.manifest.permissions.declarativeNetRequestFeedback`
+  - `webextensions.manifest.permissions.declarativeNetRequestWithHostAccess`
 
 ## May 2023
 ### Browsers released:
@@ -105,7 +436,19 @@
   - {'browser':'safari','version':'16.5'}
   - {'browser':'safari_ios','version':'16.5'}
 ### These Features became stable across all major browsers:
+  - [`api.CanvasRenderingContext2D.createConicGradient`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createConicGradient)
+  - [`api.CanvasRenderingContext2D.roundRect`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/roundRect)
+  - `api.FormData.FormData.submitter`
+  - [`api.HTMLElement.inert`](https://developer.mozilla.org/docs/Web/API/HTMLElement/inert)
+  - `api.OffscreenCanvasRenderingContext2D.roundRect`
+  - `api.Path2D.roundRect`
+  - `css.properties.hyphens.language_dutch`
+  - `css.properties.hyphens.language_italian`
+  - `css.properties.hyphens.language_russian`
+  - `css.properties.hyphens.language_swedish`
+  - `css.properties.hyphens.language_ukrainian`
   - [`html.global_attributes.inert`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inert)
+  - `webextensions.manifest.background.type`
 
 ## Apr 2023
 ### Browsers released:
@@ -113,29 +456,85 @@
   - {'browser':'edge','version':'112'}
   - {'browser':'firefox','version':'112'}
 ### These Features became stable across all major browsers:
-  - [`api.CSSFontFeatureValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule)
-  - [`api.ElementInternals`](https://developer.mozilla.org/docs/Web/API/ElementInternals)
-  - [`api.FileSystemDirectoryHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle)
-  - [`api.FileSystemFileHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle)
-  - [`api.FileSystemHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemHandle)
-  - [`api.FileSystemSyncAccessHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle)
-  - [`api.GamepadHapticActuator`](https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator)
-  - [`api.Notification`](https://developer.mozilla.org/docs/Web/API/Notification)
-  - [`api.NotificationEvent`](https://developer.mozilla.org/docs/Web/API/NotificationEvent)
-  - [`api.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas)
-  - [`api.OffscreenCanvasRenderingContext2D`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D)
-  - [`api.PerformanceServerTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming)
-  - [`api.PushEvent`](https://developer.mozilla.org/docs/Web/API/PushEvent)
-  - [`api.PushManager`](https://developer.mozilla.org/docs/Web/API/PushManager)
-  - [`api.PushMessageData`](https://developer.mozilla.org/docs/Web/API/PushMessageData)
-  - [`api.PushSubscription`](https://developer.mozilla.org/docs/Web/API/PushSubscription)
-  - [`api.PushSubscriptionOptions`](https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions)
-  - [`api.ScreenOrientation`](https://developer.mozilla.org/docs/Web/API/ScreenOrientation)
-  - [`css.properties.font-synthesis-small-caps`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps)
-  - [`css.properties.font-synthesis-style`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style)
-  - [`css.properties.font-synthesis-weight`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight)
-  - [`css.properties.font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates)
+  - [`api.CSSFontFeatureValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule) +1
+  - [`api.CSSStyleSheet.CSSStyleSheet`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/CSSStyleSheet)
+  - [`api.CSSStyleSheet.replace`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replace)
+  - [`api.CSSStyleSheet.replaceSync`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync)
+  - [`api.DedicatedWorkerGlobalScope.cancelAnimationFrame`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame)
+  - [`api.DedicatedWorkerGlobalScope.messageerror_event`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event)
+  - [`api.DedicatedWorkerGlobalScope.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)
+  - [`api.Document.adoptedStyleSheets`](https://developer.mozilla.org/docs/Web/API/Document/adoptedStyleSheets)
+  - [`api.Document.exitFullscreen`](https://developer.mozilla.org/docs/Web/API/Document/exitFullscreen) +1
+  - [`api.Document.fullscreen`](https://developer.mozilla.org/docs/Web/API/Document/fullscreen)
+  - [`api.Document.fullscreenElement`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenElement)
+  - [`api.Document.fullscreenEnabled`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenEnabled)
+  - [`api.Document.fullscreenchange_event`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenchange_event)
+  - [`api.Document.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Document/fullscreenerror_event)
+  - [`api.Element.fullscreenchange_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenchange_event)
+  - [`api.Element.fullscreenerror_event`](https://developer.mozilla.org/docs/Web/API/Element/fullscreenerror_event)
+  - [`api.Element.requestFullscreen`](https://developer.mozilla.org/docs/Web/API/Element/requestFullscreen) +1
+  - [`api.ElementInternals`](https://developer.mozilla.org/docs/Web/API/ElementInternals) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.FileSystemDirectoryHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.FileSystemFileHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle) +1 +1
+  - [`api.FileSystemHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemHandle) +1 +1 +1
+  - [`api.FileSystemSyncAccessHandle`](https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle) +1
+  - `api.FileSystemSyncAccessHandle.close.sync_version` +1
+  - `api.FileSystemSyncAccessHandle.flush.sync_version` +1
+  - `api.FileSystemSyncAccessHandle.getSize.sync_version` +1 +1
+  - `api.FileSystemSyncAccessHandle.truncate.sync_version` +1
+  - [`api.GamepadHapticActuator`](https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator) +1
+  - [`api.HTMLCanvasElement.transferControlToOffscreen`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen)
+  - [`api.HTMLElement.attachInternals`](https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals)
+  - [`api.HTMLElement.translate`](https://developer.mozilla.org/docs/Web/API/HTMLElement/translate)
+  - `api.HTMLFormElement.rel`
+  - `api.HTMLFormElement.relList`
+  - [`api.HTMLSlotElement.assign`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign)
+  - [`api.InputEvent.isComposing`](https://developer.mozilla.org/docs/Web/API/InputEvent/isComposing)
+  - [`api.MessagePort.messageerror_event`](https://developer.mozilla.org/docs/Web/API/MessagePort/messageerror_event)
+  - [`api.Navigator.pdfViewerEnabled`](https://developer.mozilla.org/docs/Web/API/Navigator/pdfViewerEnabled)
+  - [`api.Notification`](https://developer.mozilla.org/docs/Web/API/Notification) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.NotificationEvent`](https://developer.mozilla.org/docs/Web/API/NotificationEvent) +1
+  - [`api.OffscreenCanvas`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvas) +1 +1 +1
+  - `api.OffscreenCanvas.getContext.2d_context`
+  - `api.OffscreenCanvas.getContext.bitmaprenderer_context` +1 +1 +1
+  - [`api.OffscreenCanvasRenderingContext2D`](https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.PerformanceResourceTiming.decodedBodySize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/decodedBodySize)
+  - [`api.PerformanceResourceTiming.encodedBodySize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/encodedBodySize)
+  - [`api.PerformanceResourceTiming.serverTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/serverTiming)
+  - [`api.PerformanceResourceTiming.transferSize`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/transferSize)
+  - [`api.PerformanceServerTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming) +1 +1 +1 +1
+  - [`api.PermissionStatus.change_event`](https://developer.mozilla.org/docs/Web/API/PermissionStatus/change_event)
+  - [`api.PushEvent`](https://developer.mozilla.org/docs/Web/API/PushEvent) +1 +1
+  - [`api.PushManager`](https://developer.mozilla.org/docs/Web/API/PushManager) +1 +1 +1
+  - [`api.PushMessageData`](https://developer.mozilla.org/docs/Web/API/PushMessageData) +1 +1 +1 +1
+  - [`api.PushSubscription`](https://developer.mozilla.org/docs/Web/API/PushSubscription) +1 +1 +1 +1 +1 +1
+  - [`api.PushSubscriptionOptions`](https://developer.mozilla.org/docs/Web/API/PushSubscriptionOptions) +1
+  - `api.RTCStatsReport.type_inbound-rtp.trackIdentifier`
+  - [`api.SVGStyleElement.sheet`](https://developer.mozilla.org/docs/Web/API/SVGStyleElement/sheet)
+  - [`api.Screen.orientation`](https://developer.mozilla.org/docs/Web/API/Screen/orientation)
+  - [`api.ScreenOrientation`](https://developer.mozilla.org/docs/Web/API/ScreenOrientation) +1 +1 +1
+  - [`api.ServiceWorkerContainer.messageerror_event`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/messageerror_event)
+  - [`api.ServiceWorkerRegistration.getNotifications`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/getNotifications)
+  - [`api.ServiceWorkerRegistration.pushManager`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/pushManager)
+  - [`api.ServiceWorkerRegistration.showNotification`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/showNotification)
+  - [`api.ShadowRoot.adoptedStyleSheets`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/adoptedStyleSheets)
+  - [`api.ShadowRoot.fullscreenElement`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/fullscreenElement)
+  - [`api.ShadowRoot.slotAssignment`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/slotAssignment)
+  - [`api.StorageManager.getDirectory`](https://developer.mozilla.org/docs/Web/API/StorageManager/getDirectory)
+  - [`api.Window.messageerror_event`](https://developer.mozilla.org/docs/Web/API/Window/messageerror_event)
+  - [`api.WritableStreamDefaultController.signal`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal)
+  - [`css.at-rules.font-feature-values`](https://developer.mozilla.org/docs/Web/CSS/@font-feature-values) +1 +1 +1 +1 +1 +1 +1
+  - [`css.at-rules.media.or_syntax`](https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#testing_for_multiple_features_with_or)
+  - [`css.at-rules.media.range_syntax`](https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4)
+  - `css.properties.font-size.xxx-large`
+  - [`css.properties.font-synthesis-small-caps`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps) +1 +1
+  - [`css.properties.font-synthesis-style`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style) +1 +1
+  - [`css.properties.font-synthesis-weight`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight) +1 +1
+  - `css.properties.font-variant.historical-forms`
+  - [`css.properties.font-variant-alternates`](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates) +1 +1 +1 +1 +1 +1
   - [`css.properties.outline`](https://developer.mozilla.org/docs/Web/CSS/outline)
+  - `css.selectors.backdrop.fullscreen`
+  - [`css.selectors.fullscreen`](https://developer.mozilla.org/docs/Web/CSS/:fullscreen)
   - [`css.types.acos`](https://developer.mozilla.org/docs/Web/CSS/acos)
   - [`css.types.asin`](https://developer.mozilla.org/docs/Web/CSS/asin)
   - [`css.types.atan`](https://developer.mozilla.org/docs/Web/CSS/atan)
@@ -143,13 +542,22 @@
   - [`css.types.cos`](https://developer.mozilla.org/docs/Web/CSS/cos)
   - [`css.types.sin`](https://developer.mozilla.org/docs/Web/CSS/sin)
   - [`css.types.tan`](https://developer.mozilla.org/docs/Web/CSS/tan)
+  - `html.elements.form.rel`
+  - `html.elements.script.type.importmap`
   - [`html.global_attributes.translate`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/translate)
   - [`http.headers.Sec-Fetch-Dest`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Dest)
   - [`http.headers.Sec-Fetch-Mode`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Mode)
   - [`http.headers.Sec-Fetch-Site`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Site)
   - [`http.headers.Sec-Fetch-User`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-User)
+  - [`javascript.classes.static_initialization_blocks`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks)
+  - [`javascript.operators.import_meta.resolve`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta/resolve)
   - [`javascript.regular_expressions.lookbehind_assertion`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion)
   - `webassembly.fixed-width-SIMD`
+  - [`webextensions.api.scripting.RegisteredContentScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/RegisteredContentScript) +1
+  - [`webextensions.api.scripting.getRegisteredContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/getRegisteredContentScripts)
+  - [`webextensions.api.scripting.registerContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/registerContentScripts)
+  - [`webextensions.api.scripting.unregisterContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/unregisterContentScripts)
+  - [`webextensions.api.scripting.updateContentScripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/updateContentScripts)
 
 ## Mar 2023
 ### Browsers released:
@@ -160,10 +568,22 @@
   - {'browser':'safari_ios','version':'16.4'}
 ### These Features became stable across all major browsers:
   - [`api.CSSContainerRule`](https://developer.mozilla.org/docs/Web/API/CSSContainerRule)
+  - [`api.CSSPageRule.selectorText`](https://developer.mozilla.org/docs/Web/API/CSSPageRule/selectorText)
+  - [`api.HTMLElement.autofocus`](https://developer.mozilla.org/docs/Web/API/HTMLElement/autofocus)
+  - `api.MathMLElement.autofocus`
+  - `api.RTCPeerConnection.addTransceiver.init_sendEncodings_parameter`
+  - `api.SVGElement.autofocus`
   - [`css.at-rules.container`](https://developer.mozilla.org/docs/Web/CSS/@container)
+  - [`css.at-rules.media.color-gamut`](https://developer.mozilla.org/docs/Web/CSS/@media/color-gamut)
   - [`css.properties.container`](https://developer.mozilla.org/docs/Web/CSS/container)
-  - [`css.properties.container-name`](https://developer.mozilla.org/docs/Web/CSS/container-name)
-  - [`css.properties.container-type`](https://developer.mozilla.org/docs/Web/CSS/container-type)
+  - [`css.properties.container-name`](https://developer.mozilla.org/docs/Web/CSS/container-name) +1
+  - [`css.properties.container-type`](https://developer.mozilla.org/docs/Web/CSS/container-type) +1 +1 +1
+  - `css.properties.font-variant.sub`
+  - `css.properties.font-variant.super`
+  - [`css.selectors.autofill`](https://developer.mozilla.org/docs/Web/CSS/:autofill)
+  - `css.types.length.container_query_length_units`
+  - `html.elements.input.type_color.list`
+  - [`html.global_attributes.autofocus`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autofocus)
 
 ## Feb 2023
 ### Browsers released:
@@ -171,22 +591,23 @@
   - {'browser':'edge','version':'110'}
   - {'browser':'firefox','version':'110'}
 ### These Features became stable across all major browsers:
-  - [`api.MathMLElement`](https://developer.mozilla.org/docs/Web/API/MathMLElement)
+  - [`api.MathMLElement`](https://developer.mozilla.org/docs/Web/API/MathMLElement) +1 +1 +1 +1 +1
+  - [`http.headers.Content-Security-Policy.unsafe-hashes`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#unsafe-hashes)
   - [`mathml.elements.maction`](https://developer.mozilla.org/docs/Web/MathML/Element/maction)
-  - [`mathml.elements.math`](https://developer.mozilla.org/docs/Web/MathML/Element/math)
+  - [`mathml.elements.math`](https://developer.mozilla.org/docs/Web/MathML/Element/math) +1
   - [`mathml.elements.merror`](https://developer.mozilla.org/docs/Web/MathML/Element/merror)
-  - [`mathml.elements.mfrac`](https://developer.mozilla.org/docs/Web/MathML/Element/mfrac)
-  - [`mathml.elements.mi`](https://developer.mozilla.org/docs/Web/MathML/Element/mi)
+  - [`mathml.elements.mfrac`](https://developer.mozilla.org/docs/Web/MathML/Element/mfrac) +1
+  - [`mathml.elements.mi`](https://developer.mozilla.org/docs/Web/MathML/Element/mi) +1
   - [`mathml.elements.mmultiscripts`](https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts)
   - [`mathml.elements.mn`](https://developer.mozilla.org/docs/Web/MathML/Element/mn)
-  - [`mathml.elements.mo`](https://developer.mozilla.org/docs/Web/MathML/Element/mo)
-  - [`mathml.elements.mover`](https://developer.mozilla.org/docs/Web/MathML/Element/mover)
-  - [`mathml.elements.mpadded`](https://developer.mozilla.org/docs/Web/MathML/Element/mpadded)
+  - [`mathml.elements.mo`](https://developer.mozilla.org/docs/Web/MathML/Element/mo) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`mathml.elements.mover`](https://developer.mozilla.org/docs/Web/MathML/Element/mover) +1
+  - [`mathml.elements.mpadded`](https://developer.mozilla.org/docs/Web/MathML/Element/mpadded) +1 +1 +1 +1 +1
   - [`mathml.elements.mphantom`](https://developer.mozilla.org/docs/Web/MathML/Element/mphantom)
   - [`mathml.elements.mroot`](https://developer.mozilla.org/docs/Web/MathML/Element/mroot)
   - [`mathml.elements.mrow`](https://developer.mozilla.org/docs/Web/MathML/Element/mrow)
   - [`mathml.elements.ms`](https://developer.mozilla.org/docs/Web/MathML/Element/ms)
-  - [`mathml.elements.mspace`](https://developer.mozilla.org/docs/Web/MathML/Element/mspace)
+  - [`mathml.elements.mspace`](https://developer.mozilla.org/docs/Web/MathML/Element/mspace) +1 +1 +1
   - [`mathml.elements.msqrt`](https://developer.mozilla.org/docs/Web/MathML/Element/msqrt)
   - [`mathml.elements.mstyle`](https://developer.mozilla.org/docs/Web/MathML/Element/mstyle)
   - [`mathml.elements.msub`](https://developer.mozilla.org/docs/Web/MathML/Element/msub)
@@ -196,17 +617,21 @@
   - [`mathml.elements.mtd`](https://developer.mozilla.org/docs/Web/MathML/Element/mtd)
   - [`mathml.elements.mtext`](https://developer.mozilla.org/docs/Web/MathML/Element/mtext)
   - [`mathml.elements.mtr`](https://developer.mozilla.org/docs/Web/MathML/Element/mtr)
-  - [`mathml.elements.munder`](https://developer.mozilla.org/docs/Web/MathML/Element/munder)
-  - [`mathml.elements.munderover`](https://developer.mozilla.org/docs/Web/MathML/Element/munderover)
+  - [`mathml.elements.munder`](https://developer.mozilla.org/docs/Web/MathML/Element/munder) +1
+  - [`mathml.elements.munderover`](https://developer.mozilla.org/docs/Web/MathML/Element/munderover) +1 +1
   - [`mathml.elements.semantics`](https://developer.mozilla.org/docs/Web/MathML/Element/semantics)
   - [`mathml.global_attributes.dir`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir)
   - [`mathml.global_attributes.displaystyle`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle)
   - [`mathml.global_attributes.mathbackground`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathbackground)
   - [`mathml.global_attributes.mathcolor`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathcolor)
   - [`mathml.global_attributes.mathsize`](https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize)
+  - `svg.global_attributes.requiredExtensions.mathml`
   - [`webextensions.api.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action)
-  - [`webextensions.manifest.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action)
+  - [`webextensions.manifest.action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) +1 +1 +1
   - [`webextensions.manifest.host_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions)
+  - `webextensions.manifest.manifest_version.v3`
+  - [`webextensions.manifest.web_accessible_resources.matches`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#matches)
+  - [`webextensions.manifest.web_accessible_resources.resources`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#resources)
 
 ## Jan 2023
 ### Browsers released:
@@ -216,8 +641,24 @@
   - {'browser':'safari','version':'16.3'}
   - {'browser':'safari_ios','version':'16.3'}
 ### These Features became stable across all major browsers:
-  - [`api.OES_draw_buffers_indexed`](https://developer.mozilla.org/docs/Web/API/OES_draw_buffers_indexed)
+  - [`api.HTMLMediaElement.srcObject`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject)
+  - [`api.HTMLSourceElement.height`](https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/height)
+  - [`api.HTMLSourceElement.width`](https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/width)
+  - [`api.OES_draw_buffers_indexed`](https://developer.mozilla.org/docs/Web/API/OES_draw_buffers_indexed) +1 +1 +1 +1 +1 +1 +1
+  - `css.properties.align-items.flex_context.last_baseline`
+  - `css.properties.align-self.flex_context.last_baseline`
   - [`css.types.calc-constant`](https://developer.mozilla.org/docs/Web/CSS/calc-constant)
+  - `css.types.length.vb`
+  - `css.types.length.vi`
+  - `css.types.length.viewport_percentage_units_dynamic`
+  - `css.types.length.viewport_percentage_units_large`
+  - `css.types.length.viewport_percentage_units_small`
+  - `html.elements.source.height`
+  - `html.elements.source.width`
+  - [`http.headers.Content-Security-Policy.script-src-attr`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr)
+  - [`http.headers.Content-Security-Policy.script-src-elem`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem)
+  - [`http.headers.Content-Security-Policy.style-src-attr`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr)
+  - [`http.headers.Content-Security-Policy.style-src-elem`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem)
 
 
 
@@ -232,14 +673,27 @@
   - {'browser':'safari','version':'16.2'}
   - {'browser':'safari_ios','version':'16.2'}
 ### These Features became stable across all major browsers:
-  - [`api.CSSFontPaletteValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule)
-  - [`css.at-rules.font-palette-values`](https://developer.mozilla.org/docs/Web/CSS/@font-palette-values)
-  - [`css.properties.font-palette`](https://developer.mozilla.org/docs/Web/CSS/font-palette)
+  - [`api.CSSFontPaletteValuesRule`](https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule) +1 +1 +1 +1
+  - [`css.at-rules.font-palette-values`](https://developer.mozilla.org/docs/Web/CSS/@font-palette-values) +1 +1 +1
+  - [`css.properties.font-palette`](https://developer.mozilla.org/docs/Web/CSS/font-palette) +1 +1 +1
 
 ## Nov 2022
 ### Browsers released:
   - {'browser':'chrome','version':'108'}
   - {'browser':'firefox','version':'107'}
+### These Features became stable across all major browsers:
+  - [`api.HTMLMetaElement.media`](https://developer.mozilla.org/docs/Web/API/HTMLMetaElement/media)
+  - `api.RTCStatsReport.type_inbound-rtp.concealmentEvents`
+  - `api.RTCStatsReport.type_inbound-rtp.fecPacketsDiscarded`
+  - `api.RTCStatsReport.type_inbound-rtp.fecPacketsReceived`
+  - `api.RTCStatsReport.type_inbound-rtp.headerBytesReceived`
+  - `api.RTCStatsReport.type_inbound-rtp.insertedSamplesForDeceleration`
+  - `api.RTCStatsReport.type_inbound-rtp.removedSamplesForAcceleration`
+  - `api.RTCStatsReport.type_inbound-rtp.totalAudioEnergy`
+  - `api.RTCStatsReport.type_inbound-rtp.totalSamplesDuration`
+  - `css.properties.grid-template-columns.animation`
+  - `css.properties.grid-template-rows.animation`
+  - `css.types.length.ic`
 
 ## Oct 2022
 ### Browsers released:
@@ -249,20 +703,53 @@
   - {'browser':'safari','version':'16.1'}
   - {'browser':'safari_ios','version':'16.1'}
 ### These Features became stable across all major browsers:
-  - [`api.PermissionStatus`](https://developer.mozilla.org/docs/Web/API/PermissionStatus)
-  - [`api.Permissions`](https://developer.mozilla.org/docs/Web/API/Permissions)
-  - [`api.SharedWorker`](https://developer.mozilla.org/docs/Web/API/SharedWorker)
-  - [`api.SharedWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope)
-  - [`api.TextDecoderStream`](https://developer.mozilla.org/docs/Web/API/TextDecoderStream)
-  - [`api.TextEncoderStream`](https://developer.mozilla.org/docs/Web/API/TextEncoderStream)
+  - [`api.AbortSignal.timeout_static`](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static)
+  - `api.Element.animate.options_composite_parameter`
+  - [`api.FetchEvent.handled`](https://developer.mozilla.org/docs/Web/API/FetchEvent/handled)
+  - [`api.FetchEvent.resultingClientId`](https://developer.mozilla.org/docs/Web/API/FetchEvent/resultingClientId)
+  - [`api.HTMLFormElement.requestSubmit`](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/requestSubmit)
+  - [`api.HTMLInputElement.showPicker`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker) +1
+  - [`api.HTMLScriptElement.supports_static`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/supports_static)
+  - [`api.KeyframeEffect.composite`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite)
+  - [`api.Navigator.permissions`](https://developer.mozilla.org/docs/Web/API/Navigator/permissions)
+  - [`api.PermissionStatus`](https://developer.mozilla.org/docs/Web/API/PermissionStatus) +1 +1
+  - [`api.Permissions`](https://developer.mozilla.org/docs/Web/API/Permissions) +1 +1
+  - [`api.SharedWorker`](https://developer.mozilla.org/docs/Web/API/SharedWorker) +1 +1 +1
+  - [`api.SharedWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope) +1 +1 +1
+  - [`api.SpeechSynthesis.voiceschanged_event`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesis/voiceschanged_event)
+  - [`api.SpeechSynthesisErrorEvent.SpeechSynthesisErrorEvent`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisErrorEvent/SpeechSynthesisErrorEvent)
+  - [`api.SpeechSynthesisEvent.SpeechSynthesisEvent`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/SpeechSynthesisEvent)
+  - [`api.SpeechSynthesisEvent.charLength`](https://developer.mozilla.org/docs/Web/API/SpeechSynthesisEvent/charLength)
+  - [`api.TextDecoderStream`](https://developer.mozilla.org/docs/Web/API/TextDecoderStream) +1 +1 +1 +1 +1 +1
+  - [`api.TextEncoderStream`](https://developer.mozilla.org/docs/Web/API/TextEncoderStream) +1 +1 +1 +1
+  - [`api.WindowClient.navigate`](https://developer.mozilla.org/docs/Web/API/WindowClient/navigate)
+  - [`api.WorkerGlobalScope.fonts`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/fonts)
+  - `api.WorkerGlobalScope.importScripts.mime_checks`
+  - [`css.at-rules.media.forced-colors`](https://developer.mozilla.org/docs/Web/CSS/@media/forced-colors)
+  - [`css.at-rules.media.resolution`](https://developer.mozilla.org/docs/Web/CSS/@media/resolution)
+  - [`css.properties.contain.inline-size`](https://developer.mozilla.org/docs/Web/CSS/contain#inline-size)
+  - `css.properties.flex-basis.fit-content`
+  - `css.properties.flex-basis.max-content`
+  - `css.properties.flex-basis.min-content`
   - [`css.properties.offset`](https://developer.mozilla.org/docs/Web/CSS/offset)
-  - [`css.properties.overscroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior)
-  - [`css.properties.overscroll-behavior-block`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block)
-  - [`css.properties.overscroll-behavior-inline`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline)
-  - [`css.properties.overscroll-behavior-x`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x)
-  - [`css.properties.overscroll-behavior-y`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y)
-  - [`css.properties.text-align-last`](https://developer.mozilla.org/docs/Web/CSS/text-align-last)
+  - [`css.properties.offset-distance`](https://developer.mozilla.org/docs/Web/CSS/offset-distance)
+  - `css.properties.offset-path.path`
+  - [`css.properties.offset-rotate`](https://developer.mozilla.org/docs/Web/CSS/offset-rotate) +1 +1
+  - `css.properties.overflow.clip`
+  - `css.properties.overflow-x.clip`
+  - `css.properties.overflow-y.clip`
+  - [`css.properties.overscroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior) +1 +1 +1
+  - [`css.properties.overscroll-behavior-block`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block) +1 +1 +1
+  - [`css.properties.overscroll-behavior-inline`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline) +1 +1 +1
+  - [`css.properties.overscroll-behavior-x`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x) +1 +1 +1
+  - [`css.properties.overscroll-behavior-y`](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y) +1
+  - [`css.properties.text-align-last`](https://developer.mozilla.org/docs/Web/CSS/text-align-last) +1
+  - `css.properties.user-select.all`
   - [`css.selectors.modal`](https://developer.mozilla.org/docs/Web/CSS/:modal)
+  - [`css.types.basic-shape.path`](https://developer.mozilla.org/docs/Web/CSS/path) +1
+  - `css.types.overflow.clip`
+  - `http.headers.Content-Security-Policy.script-src.wasm-unsafe-eval`
+  - `webextensions.manifest.permissions.unlimitedStorage`
 
 ## Sep 2022
 ### Browsers released:
@@ -271,9 +758,19 @@
   - {'browser':'safari','version':'16'}
   - {'browser':'safari_ios','version':'16'}
 ### These Features became stable across all major browsers:
-  - [`css.properties.rotate`](https://developer.mozilla.org/docs/Web/CSS/rotate)
-  - [`css.properties.scale`](https://developer.mozilla.org/docs/Web/CSS/scale)
-  - [`css.properties.translate`](https://developer.mozilla.org/docs/Web/CSS/translate)
+  - `api.RTCStatsReport.type_inbound-rtp.concealedSamples`
+  - `api.RTCStatsReport.type_inbound-rtp.jitterBufferDelay`
+  - `api.RTCStatsReport.type_inbound-rtp.jitterBufferEmittedCount`
+  - `api.RTCStatsReport.type_inbound-rtp.silentConcealedSamples`
+  - `api.RTCStatsReport.type_inbound-rtp.totalSamplesReceived`
+  - [`api.SVGStyleElement.disabled`](https://developer.mozilla.org/docs/Web/API/SVGStyleElement/disabled)
+  - [`css.properties.rotate`](https://developer.mozilla.org/docs/Web/CSS/rotate) +1 +1
+  - [`css.properties.scale`](https://developer.mozilla.org/docs/Web/CSS/scale) +1
+  - [`css.properties.translate`](https://developer.mozilla.org/docs/Web/CSS/translate) +1
+  - [`javascript.builtins.Array.findLast`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast)
+  - [`javascript.builtins.Array.findLastIndex`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex)
+  - [`javascript.builtins.TypedArray.findLast`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast)
+  - [`javascript.builtins.TypedArray.findLastIndex`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLastIndex)
 
 ## Aug 2022
 ### Browsers released:
@@ -281,8 +778,14 @@
   - {'browser':'edge','version':'105'}
   - {'browser':'firefox','version':'104'}
 ### These Features became stable across all major browsers:
+  - `api.Performance.measure.measureOptions_parameter`
+  - `api.Performance.measure.returns_performancemeasure`
+  - [`api.PerformanceMeasure.detail`](https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail)
+  - `api.caches.secure_context_required`
+  - `css.properties.align-content.flex_context.start_end`
   - [`css.properties.backdrop-filter`](https://developer.mozilla.org/docs/Web/CSS/backdrop-filter)
-  - [`css.properties.scroll-snap-stop`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop)
+  - [`css.properties.contain.style`](https://developer.mozilla.org/docs/Web/CSS/contain#style)
+  - [`css.properties.scroll-snap-stop`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop) +1 +1
 
 ## Jul 2022
 ### Browsers released:
@@ -290,9 +793,14 @@
   - {'browser':'safari','version':'15.6'}
   - {'browser':'safari_ios','version':'15.6'}
 ### These Features became stable across all major browsers:
-  - [`api.TransformStream`](https://developer.mozilla.org/docs/Web/API/TransformStream)
-  - [`api.TransformStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController)
-  - [`webextensions.api.scripting`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/)
+  - [`api.ReadableStream.pipeThrough`](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeThrough)
+  - [`api.TransformStream`](https://developer.mozilla.org/docs/Web/API/TransformStream) +1 +1 +1
+  - [`api.TransformStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/TransformStreamDefaultController) +1 +1 +1 +1
+  - [`webextensions.api.scripting`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/) +1
+  - `webextensions.api.scripting.ExecutionWorld.ISOLATED` +1 +1
+  - `webextensions.api.scripting.executeScript.world` +1 +1
+  - `webextensions.manifest.optional_permissions.scripting`
+  - `webextensions.manifest.permissions.scripting`
 
 ## Jun 2022
 ### Browsers released:
@@ -300,10 +808,28 @@
   - {'browser':'edge','version':'103'}
   - {'browser':'firefox','version':'102'}
 ### These Features became stable across all major browsers:
-  - [`api.WritableStream`](https://developer.mozilla.org/docs/Web/API/WritableStream)
-  - [`api.WritableStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController)
-  - [`api.WritableStreamDefaultWriter`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter)
+  - [`api.CanvasRenderingContext2D.direction`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/direction)
+  - `api.HTMLElement.focus.options_preventScroll_parameter`
+  - `api.Performance.mark.markOptions_parameter`
+  - `api.Performance.mark.returns_performancemark`
+  - [`api.PerformanceMark.PerformanceMark`](https://developer.mozilla.org/docs/Web/API/PerformanceMark/PerformanceMark)
+  - [`api.PerformanceMark.detail`](https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail)
+  - `api.RTCRtpSender.setParameters.parameters_encodings_parameter.maxFramerate`
+  - `api.RTCStatsReport.type_outbound-rtp.headerBytesSent`
+  - `api.RTCStatsReport.type_outbound-rtp.retransmittedBytesSent`
+  - `api.RTCStatsReport.type_outbound-rtp.retransmittedPacketsSent`
+  - [`api.ReadableStream.pipeTo`](https://developer.mozilla.org/docs/Web/API/ReadableStream/pipeTo)
+  - [`api.WritableStream`](https://developer.mozilla.org/docs/Web/API/WritableStream) +1 +1 +1 +1 +1
+  - [`api.WritableStreamDefaultController`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController) +1
+  - [`api.WritableStreamDefaultWriter`](https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultWriter) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.at-rules.media.dynamic-range`](https://developer.mozilla.org/docs/Web/CSS/@media/dynamic-range)
+  - [`css.at-rules.media.prefers-contrast`](https://developer.mozilla.org/docs/Web/CSS/@media/prefers-contrast)
+  - [`http.headers.Content-Security-Policy.worker-src`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
+  - [`webassembly.api.Exception`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception) +1
+  - [`webassembly.api.Exception.Exception.options_parameter_traceStack`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/Exception) +1 +1
+  - [`webassembly.api.Tag`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag) +1
   - `webassembly.exception-handling`
+  - [`webextensions.api.storage.StorageArea.onChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged)
 
 ## May 2022
 ### Browsers released:
@@ -313,8 +839,14 @@
   - {'browser':'safari','version':'15.5'}
   - {'browser':'safari_ios','version':'15.5'}
 ### These Features became stable across all major browsers:
-  - [`api.NavigationPreloadManager`](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager)
+  - [`api.FetchEvent.preloadResponse`](https://developer.mozilla.org/docs/Web/API/FetchEvent/preloadResponse)
+  - [`api.MediaCapabilities.encodingInfo`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo)
+  - [`api.NavigationPreloadManager`](https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager) +1 +1 +1 +1
+  - [`api.RTCPeerConnection.setConfiguration`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/setConfiguration)
+  - [`api.ServiceWorkerRegistration.navigationPreload`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/navigationPreload)
+  - `css.properties.mix-blend-mode.plus-lighter`
   - [`css.properties.scroll-snap-type`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type)
+  - [`css.types.color.hwb`](https://developer.mozilla.org/docs/Web/CSS/color_value/hwb)
 
 ## Apr 2022
 ### Browsers released:
@@ -322,40 +854,90 @@
   - {'browser':'edge','version':'101'}
   - {'browser':'firefox','version':'99'}
 ### These Features became stable across all major browsers:
-  - [`api.BroadcastChannel`](https://developer.mozilla.org/docs/Web/API/BroadcastChannel)
-  - [`api.CSSLayerBlockRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule)
-  - [`api.CSSLayerStatementRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule)
-  - [`api.HTMLDialogElement`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement)
-  - [`api.Lock`](https://developer.mozilla.org/docs/Web/API/Lock)
-  - [`api.LockManager`](https://developer.mozilla.org/docs/Web/API/LockManager)
-  - [`api.RTCDtlsTransport`](https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport)
-  - [`api.ResizeObserverSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverSize)
+  - `api.AbortSignal.abort_static.reason_parameter`
+  - [`api.AbortSignal.reason`](https://developer.mozilla.org/docs/Web/API/AbortSignal/reason)
+  - [`api.AbortSignal.throwIfAborted`](https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted)
+  - [`api.BroadcastChannel`](https://developer.mozilla.org/docs/Web/API/BroadcastChannel) +1 +1 +1 +1 +1 +1
+  - [`api.CSSImportRule.layerName`](https://developer.mozilla.org/docs/Web/API/CSSImportRule/layerName)
+  - [`api.CSSLayerBlockRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule) +1
+  - [`api.CSSLayerStatementRule`](https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule) +1
+  - [`api.Crypto.randomUUID`](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID)
+  - [`api.Document.securitypolicyviolation_event`](https://developer.mozilla.org/docs/Web/API/Document/securitypolicyviolation_event)
+  - [`api.HTMLDialogElement`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement) +1 +1 +1 +1 +1 +1 +1
+  - [`api.HTMLElement.nonce`](https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce)
+  - [`api.HTMLElement.outerText`](https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText)
+  - [`api.HTMLImageElement.loading`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/loading)
+  - [`api.Lock`](https://developer.mozilla.org/docs/Web/API/Lock) +1 +1
+  - [`api.LockManager`](https://developer.mozilla.org/docs/Web/API/LockManager) +1 +1
+  - [`api.Navigator.locks`](https://developer.mozilla.org/docs/Web/API/Navigator/locks)
+  - [`api.RTCDtlsTransport`](https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport) +1 +1
+  - [`api.RTCPeerConnection.canTrickleIceCandidates`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/canTrickleIceCandidates)
+  - `api.RTCPeerConnection.setRemoteDescription.implicit_rollback`
+  - [`api.RTCRtpReceiver.transport`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/transport)
+  - [`api.RTCRtpSender.transport`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/transport)
+  - [`api.RTCStatsReport.type_codec`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#codec) +1 +1 +1 +1 +1 +1 +1 +1
+  - `api.RTCStatsReport.type_inbound-rtp.packetsDiscarded`
+  - `api.RTCStatsReport.type_outbound-rtp.codecId`
+  - `api.RTCStatsReport.type_outbound-rtp.nackCount`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.codecId`
+  - `api.RTCStatsReport.type_remote-outbound-rtp.codecId`
+  - [`api.ResizeObserverEntry.borderBoxSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry/borderBoxSize)
+  - [`api.ResizeObserverEntry.contentBoxSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry/contentBoxSize)
+  - [`api.ResizeObserverSize`](https://developer.mozilla.org/docs/Web/API/ResizeObserverSize) +1 +1
+  - `api.SVGElement.nonce`
+  - [`api.SubmitEvent.submitter`](https://developer.mozilla.org/docs/Web/API/SubmitEvent/submitter)
+  - `api.Window.moveTo.relative-multi-screen`
+  - `api.Window.open.relative-multi-screen`
+  - `api.Window.screenLeft.relative-multi-screen`
+  - `api.Window.screenTop.relative-multi-screen`
+  - `api.Window.screenX.relative-multi-screen`
+  - `api.Window.screenY.relative-multi-screen`
+  - [`api.WorkerNavigator.locks`](https://developer.mozilla.org/docs/Web/API/WorkerNavigator/locks)
+  - [`api.WorkerNavigator.mediaCapabilities`](https://developer.mozilla.org/docs/Web/API/WorkerNavigator/mediaCapabilities)
+  - `api.createImageBitmap.options_colorSpaceConversion_parameter`
+  - `api.createImageBitmap.options_resizeHeight_parameter`
+  - `api.createImageBitmap.options_resizeWidth_parameter`
   - [`api.reportError`](https://developer.mozilla.org/docs/Web/API/reportError)
   - [`api.structuredClone`](https://developer.mozilla.org/docs/Web/API/structuredClone)
+  - `css.at-rules.import.layer`
   - [`css.at-rules.layer`](https://developer.mozilla.org/docs/Web/CSS/@layer)
-  - [`css.properties.accent-color`](https://developer.mozilla.org/docs/Web/CSS/accent-color)
-  - [`css.properties.appearance`](https://developer.mozilla.org/docs/Web/CSS/appearance)
+  - [`css.properties.accent-color`](https://developer.mozilla.org/docs/Web/CSS/accent-color) +1
+  - `css.properties.align-items.flex_context.start_end`
+  - `css.properties.align-self.flex_context.start_end`
+  - [`css.properties.appearance`](https://developer.mozilla.org/docs/Web/CSS/appearance) +1
   - [`css.properties.backface-visibility`](https://developer.mozilla.org/docs/Web/CSS/backface-visibility)
-  - [`css.properties.contain`](https://developer.mozilla.org/docs/Web/CSS/contain)
-  - [`css.properties.mask-clip`](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
-  - [`css.properties.mask-image`](https://developer.mozilla.org/docs/Web/CSS/mask-image)
-  - [`css.properties.mask-origin`](https://developer.mozilla.org/docs/Web/CSS/mask-origin)
-  - [`css.properties.mask-position`](https://developer.mozilla.org/docs/Web/CSS/mask-position)
-  - [`css.properties.mask-repeat`](https://developer.mozilla.org/docs/Web/CSS/mask-repeat)
-  - [`css.properties.mask-size`](https://developer.mozilla.org/docs/Web/CSS/mask-size)
+  - `css.properties.background-attachment.fixed`
+  - `css.properties.background-attachment.local`
+  - [`css.properties.contain`](https://developer.mozilla.org/docs/Web/CSS/contain) +1 +1 +1 +1 +1 +1
+  - `css.properties.flex-basis.content`
+  - `css.properties.hyphenate-character.auto`
+  - `css.properties.justify-content.flex_context.start_end`
+  - [`css.properties.mask`](https://developer.mozilla.org/docs/Web/CSS/mask)
   - [`css.properties.offset-path`](https://developer.mozilla.org/docs/Web/CSS/offset-path)
+  - `css.properties.overflow-wrap.anywhere`
   - [`css.properties.print-color-adjust`](https://developer.mozilla.org/docs/Web/CSS/print-color-adjust)
-  - [`css.properties.scroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior)
+  - [`css.properties.scroll-behavior`](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior) +1 +1
+  - `css.properties.text-align.match-parent`
   - [`css.properties.text-combine-upright`](https://developer.mozilla.org/docs/Web/CSS/text-combine-upright)
-  - [`css.properties.text-decoration-skip-ink`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink)
+  - [`css.properties.text-decoration-skip-ink`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink) +1 +1
   - [`css.properties.text-emphasis`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis)
   - [`css.properties.text-emphasis-color`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color)
   - [`css.properties.text-emphasis-position`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position)
   - [`css.properties.text-emphasis-style`](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style)
-  - [`css.selectors.backdrop`](https://developer.mozilla.org/docs/Web/CSS/::backdrop)
+  - [`css.selectors.backdrop`](https://developer.mozilla.org/docs/Web/CSS/::backdrop) +1
   - [`css.selectors.focus-visible`](https://developer.mozilla.org/docs/Web/CSS/:focus-visible)
-  - [`html.elements.dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog)
+  - [`html.elements.dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) +1
+  - `html.elements.img.loading`
+  - [`http.headers.Content-Security-Policy.strict-dynamic`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#strict-dynamic)
+  - [`javascript.builtins.Array.at`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/at)
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_timeZoneName_parameter.extended_values`
+  - [`javascript.builtins.Intl.supportedValuesOf`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf)
+  - [`javascript.builtins.Object.hasOwn`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)
+  - [`javascript.builtins.String.at`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/at)
+  - [`javascript.builtins.TypedArray.at`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/at)
   - [`webextensions.api.runtime.onMessageExternal`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal)
+  - `webextensions.manifest.background.persistent`
+  - [`webextensions.manifest.content_security_policy.extension_pages`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#extension_pages)
 
 ## Mar 2022
 ### Browsers released:
@@ -364,6 +946,10 @@
   - {'browser':'firefox','version':'98'}
   - {'browser':'safari','version':'15.4'}
   - {'browser':'safari_ios','version':'15.4'}
+### These Features became stable across all major browsers:
+  - `api.ImageBitmapRenderingContext.canvas`
+  - `css.properties.color-scheme.only_dark`
+  - `css.properties.color-scheme.only_light`
 
 ## Feb 2022
 ### Browsers released:
@@ -371,8 +957,11 @@
   - {'browser':'edge','version':'98'}
   - {'browser':'firefox','version':'97'}
 ### These Features became stable across all major browsers:
+  - `api.Navigator.canShare.data_text_parameter`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.roundTripTime`
   - [`css.properties.color-scheme`](https://developer.mozilla.org/docs/Web/CSS/color-scheme)
-  - [`css.properties.font-synthesis`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis)
+  - [`css.properties.font-synthesis`](https://developer.mozilla.org/docs/Web/CSS/font-synthesis) +1
+  - `html.elements.meta.name.color-scheme`
 
 ## Jan 2022
 ### Browsers released:
@@ -382,12 +971,18 @@
   - {'browser':'safari','version':'15.3'}
   - {'browser':'safari_ios','version':'15.3'}
 ### These Features became stable across all major browsers:
-  - [`api.StorageManager`](https://developer.mozilla.org/docs/Web/API/StorageManager)
+  - [`api.HTMLElement.inputMode`](https://developer.mozilla.org/docs/Web/API/HTMLElement/inputMode)
+  - [`api.Navigator.storage`](https://developer.mozilla.org/docs/Web/API/Navigator/storage)
+  - [`api.StorageManager`](https://developer.mozilla.org/docs/Web/API/StorageManager) +1 +1
+  - [`api.WorkerNavigator.storage`](https://developer.mozilla.org/docs/Web/API/WorkerNavigator/storage)
   - [`api.crossOriginIsolated`](https://developer.mozilla.org/docs/Web/API/crossOriginIsolated)
   - [`http.headers.Cross-Origin-Embedder-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)
   - [`http.headers.Cross-Origin-Opener-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
-  - [`javascript.builtins.Atomics`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics)
-  - [`javascript.builtins.SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
+  - [`javascript.builtins.Atomics`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - `javascript.builtins.DataView.DataView.sharedarraybuffer_support`
+  - [`javascript.builtins.SharedArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) +1 +1 +1 +1
+  - `webassembly.api.Memory.Memory.shared`
+  - `webassembly.threads-and-atomics`
 
 
 
@@ -401,6 +996,21 @@
   - {'browser':'safari','version':'15.2'}
   - {'browser':'safari_ios','version':'15.2'}
 ### These Features became stable across all major browsers:
+  - `api.Element.attachShadow.init_delegatesFocus_parameter`
+  - [`api.HTMLElement.enterKeyHint`](https://developer.mozilla.org/docs/Web/API/HTMLElement/enterKeyHint)
+  - [`api.ShadowRoot.delegatesFocus`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus)
+  - `css.properties.block-size.fit-content`
+  - `css.properties.height.fit-content`
+  - `css.properties.inline-size.fit-content`
+  - `css.properties.max-block-size.fit-content`
+  - `css.properties.max-height.fit-content`
+  - `css.properties.max-inline-size.fit-content`
+  - `css.properties.max-width.fit-content`
+  - `css.properties.min-block-size.fit-content`
+  - `css.properties.min-height.fit-content`
+  - `css.properties.min-inline-size.fit-content`
+  - `css.properties.min-width.fit-content`
+  - `css.properties.width.fit-content`
   - [`html.global_attributes.enterkeyhint`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/enterkeyhint)
   - `webassembly.reference-types`
 
@@ -410,7 +1020,14 @@
   - {'browser':'edge','version':'96'}
   - {'browser':'firefox','version':'94'}
 ### These Features became stable across all major browsers:
-  - [`api.PerformanceNavigationTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming)
+  - [`api.PerformanceNavigationTiming`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.SVGAnimationElement.beginEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/beginEvent_event)
+  - [`api.SVGAnimationElement.endEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/endEvent_event)
+  - [`api.SVGAnimationElement.repeatEvent_event`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeatEvent_event)
+  - `api.createImageBitmap.options_imageOrientation_parameter`
+  - `api.createImageBitmap.options_premultiplyAlpha_parameter`
+  - `css.properties.image-rendering.pixelated`
+  - [`html.elements.input.type_datetime-local`](https://developer.mozilla.org/docs/Web/HTML/Element/input/datetime-local)
 
 ## Oct 2021
 ### Browsers released:
@@ -420,40 +1037,99 @@
   - {'browser':'safari','version':'15.1'}
   - {'browser':'safari_ios','version':'15.1'}
 ### These Features became stable across all major browsers:
+  - [`api.AbortSignal.abort_static`](https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static)
+  - `api.CanvasRenderingContext2D.drawImage.ImageBitmap_source_image`
+  - `api.Crypto.subtle.secure_context_required`
   - [`api.EXT_color_buffer_float`](https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_float)
-  - [`api.FormDataEvent`](https://developer.mozilla.org/docs/Web/API/FormDataEvent)
-  - [`api.ImageBitmap`](https://developer.mozilla.org/docs/Web/API/ImageBitmap)
-  - [`api.MediaSession`](https://developer.mozilla.org/docs/Web/API/MediaSession)
-  - [`api.SubmitEvent`](https://developer.mozilla.org/docs/Web/API/SubmitEvent)
+  - `api.EventTarget.addEventListener.options_parameter.options_signal_parameter`
+  - [`api.FormDataEvent`](https://developer.mozilla.org/docs/Web/API/FormDataEvent) +1 +1
+  - `api.HTMLCanvasElement.getContext.webgl2_context` +1 +1 +1
+  - [`api.HTMLFormElement.formdata_event`](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event)
+  - [`api.IDBCursor.request`](https://developer.mozilla.org/docs/Web/API/IDBCursor/request)
+  - [`api.IDBTransaction.commit`](https://developer.mozilla.org/docs/Web/API/IDBTransaction/commit)
+  - [`api.ImageBitmap`](https://developer.mozilla.org/docs/Web/API/ImageBitmap) +1 +1 +1
+  - [`api.MediaError.message`](https://developer.mozilla.org/docs/Web/API/MediaError/message)
+  - [`api.MediaSession`](https://developer.mozilla.org/docs/Web/API/MediaSession) +1 +1 +1
+  - `api.MediaSession.setActionHandler.nexttrack_type`
+  - `api.MediaSession.setActionHandler.pause_type`
+  - `api.MediaSession.setActionHandler.play_type`
+  - `api.MediaSession.setActionHandler.previoustrack_type`
+  - `api.MediaSession.setActionHandler.seekbackward_type`
+  - `api.MediaSession.setActionHandler.seekforward_type`
+  - `api.MediaSession.setActionHandler.seekto_type`
+  - `api.MediaSession.setActionHandler.stop_type` +1
+  - [`api.Navigator.mediaSession`](https://developer.mozilla.org/docs/Web/API/Navigator/mediaSession)
+  - `api.Navigator.share.data_text_parameter`
+  - [`api.Performance.timeOrigin`](https://developer.mozilla.org/docs/Web/API/Performance/timeOrigin)
+  - [`api.PerformanceObserver.takeRecords`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver/takeRecords)
+  - [`api.SecurityPolicyViolationEvent.disposition`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent/disposition)
+  - [`api.SecurityPolicyViolationEvent.sample`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent/sample)
+  - [`api.SubmitEvent`](https://developer.mozilla.org/docs/Web/API/SubmitEvent) +1
+  - `api.SubtleCrypto.secure_context_required`
   - [`api.WEBGL_color_buffer_float`](https://developer.mozilla.org/docs/Web/API/WEBGL_color_buffer_float)
-  - [`api.WEBGL_draw_buffers`](https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers)
-  - [`api.WebGL2RenderingContext`](https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext)
+  - [`api.WEBGL_draw_buffers`](https://developer.mozilla.org/docs/Web/API/WEBGL_draw_buffers) +1
+  - [`api.WebGL2RenderingContext`](https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
   - [`api.WebGLQuery`](https://developer.mozilla.org/docs/Web/API/WebGLQuery)
   - [`api.WebGLSampler`](https://developer.mozilla.org/docs/Web/API/WebGLSampler)
   - [`api.WebGLSync`](https://developer.mozilla.org/docs/Web/API/WebGLSync)
   - [`api.WebGLTransformFeedback`](https://developer.mozilla.org/docs/Web/API/WebGLTransformFeedback)
   - [`api.WebGLVertexArrayObject`](https://developer.mozilla.org/docs/Web/API/WebGLVertexArrayObject)
+  - [`api.XMLHttpRequest.send.body_URLSearchParams_type`](https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/send#URLSearchParams)
   - [`api.createImageBitmap`](https://developer.mozilla.org/docs/Web/API/createImageBitmap)
-  - [`css.properties.aspect-ratio`](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio)
+  - [`css.properties.aspect-ratio`](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio) +1
   - [`css.properties.border-end-end-radius`](https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius)
   - [`css.properties.border-end-start-radius`](https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius)
   - [`css.properties.border-start-end-radius`](https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius)
   - [`css.properties.border-start-start-radius`](https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius)
+  - `css.properties.break-inside.multicol_context.avoid-column`
+  - `css.properties.font-family.system-ui`
+  - `css.properties.justify-content.flex_context.left_right`
+  - `css.properties.list-style-type.cjk-decimal`
+  - `css.properties.list-style-type.disclosure-closed`
+  - `css.properties.list-style-type.disclosure-open`
+  - `css.properties.list-style-type.ethiopic-numeric`
+  - `css.properties.list-style-type.japanese-formal`
+  - `css.properties.list-style-type.japanese-informal`
+  - `css.properties.list-style-type.korean-hangul-formal`
+  - `css.properties.list-style-type.korean-hanja-formal`
+  - `css.properties.list-style-type.korean-hanja-informal`
+  - `css.properties.list-style-type.simp-chinese-formal`
+  - `css.properties.list-style-type.simp-chinese-informal`
+  - `css.properties.list-style-type.tamil`
+  - `css.properties.list-style-type.trad-chinese-formal`
+  - `css.properties.list-style-type.trad-chinese-informal`
   - [`css.properties.scroll-margin-block`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block)
   - [`css.properties.scroll-margin-block-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end)
   - [`css.properties.scroll-margin-block-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start)
   - [`css.properties.scroll-margin-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline)
   - [`css.properties.scroll-margin-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end)
   - [`css.properties.scroll-margin-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start)
-  - [`css.properties.scroll-padding-block`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block)
-  - [`css.properties.scroll-padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end)
-  - [`css.properties.scroll-padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start)
-  - [`css.properties.scroll-padding-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline)
-  - [`css.properties.scroll-padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end)
-  - [`css.properties.scroll-padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start)
-  - [`css.selectors.autofill`](https://developer.mozilla.org/docs/Web/CSS/:autofill)
-  - [`javascript.builtins.BigInt64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array)
-  - [`javascript.builtins.BigUint64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array)
+  - [`css.properties.scroll-padding-block`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block) +1
+  - [`css.properties.scroll-padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end) +1
+  - [`css.properties.scroll-padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start) +1
+  - [`css.properties.scroll-padding-inline`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline) +1
+  - [`css.properties.scroll-padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end) +1
+  - [`css.properties.scroll-padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start) +1
+  - `css.selectors.link.not_match_link`
+  - `css.selectors.visited.not_match_link`
+  - `css.types.image.gradient.linear-gradient.premultiplied_gradients`
+  - `css.types.image.gradient.radial-gradient.premultiplied_gradients`
+  - `html.elements.img.aspect_ratio_computed_from_attributes`
+  - `http.headers.Referrer-Policy.default_strict-origin-when-cross-origin`
+  - [`javascript.builtins.BigInt64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array) +1
+  - [`javascript.builtins.BigUint64Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array) +1
+  - [`javascript.builtins.DataView.getBigInt64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64)
+  - [`javascript.builtins.DataView.getBigUint64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64)
+  - [`javascript.builtins.DataView.setBigInt64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64)
+  - [`javascript.builtins.DataView.setBigUint64`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64)
+  - `javascript.builtins.Error.Error.options_cause_parameter`
+  - `javascript.builtins.Error.cause`
+  - [`javascript.builtins.RegExp.hasIndices`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices)
+  - [`javascript.classes.private_class_fields_in`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
+  - [`javascript.classes.private_class_methods`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
+  - [`javascript.operators.await.top_level`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await#top_level_await)
+  - [`webassembly.api.compileStreaming_static`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compileStreaming_static)
+  - [`webassembly.api.instantiateStreaming_static`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static)
   - [`webextensions.api.alarms.Alarm`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm)
   - [`webextensions.api.alarms.clear`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear)
   - [`webextensions.api.alarms.clearAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll)
@@ -469,28 +1145,29 @@
   - [`webextensions.api.browserAction.getBadgeText`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeText)
   - [`webextensions.api.browserAction.getPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getPopup)
   - [`webextensions.api.browserAction.getTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getTitle)
-  - [`webextensions.api.browserAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked)
+  - [`webextensions.api.browserAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked) +1
   - [`webextensions.api.browserAction.setBadgeBackgroundColor`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor)
   - [`webextensions.api.browserAction.setBadgeText`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText)
-  - [`webextensions.api.browserAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon)
+  - [`webextensions.api.browserAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon) +1
   - [`webextensions.api.browserAction.setPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup)
   - [`webextensions.api.browserAction.setTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setTitle)
-  - [`webextensions.api.commands.Command`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command)
+  - [`webextensions.api.commands.Command`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/Command) +1
   - [`webextensions.api.commands.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/getAll)
-  - [`webextensions.api.commands.onCommand`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand)
-  - [`webextensions.api.cookies.Cookie`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie)
-  - [`webextensions.api.cookies.CookieStore`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore)
+  - [`webextensions.api.commands.onCommand`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onCommand) +1
+  - [`webextensions.api.cookies.Cookie`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie) +1
+  - [`webextensions.api.cookies.CookieStore`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/CookieStore) +1 +1
   - [`webextensions.api.cookies.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/get)
   - [`webextensions.api.cookies.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAll)
   - [`webextensions.api.cookies.getAllCookieStores`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/getAllCookieStores)
   - [`webextensions.api.cookies.remove`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/remove)
   - [`webextensions.api.cookies.sameSiteStatus`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/sameSiteStatus)
-  - [`webextensions.api.cookies.set`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set)
+  - [`webextensions.api.cookies.set`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set) +1
+  - [`webextensions.api.events.Event`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event) +1 +1 +1
   - [`webextensions.api.events.UrlFilter`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter)
   - [`webextensions.api.extension.ViewType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/ViewType)
   - [`webextensions.api.extension.getBackgroundPage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage)
   - [`webextensions.api.extension.getURL`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL)
-  - [`webextensions.api.extension.getViews`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews)
+  - [`webextensions.api.extension.getViews`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getViews) +1
   - [`webextensions.api.extension.inIncognitoContext`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext)
   - [`webextensions.api.extension.isAllowedFileSchemeAccess`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedFileSchemeAccess)
   - [`webextensions.api.extension.isAllowedIncognitoAccess`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/isAllowedIncognitoAccess)
@@ -503,8 +1180,8 @@
   - [`webextensions.api.pageAction.ImageDataType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/ImageDataType)
   - [`webextensions.api.pageAction.getPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getPopup)
   - [`webextensions.api.pageAction.getTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/getTitle)
-  - [`webextensions.api.pageAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked)
-  - [`webextensions.api.pageAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon)
+  - [`webextensions.api.pageAction.onClicked`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked) +1
+  - [`webextensions.api.pageAction.setIcon`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setIcon) +1
   - [`webextensions.api.pageAction.setPopup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setPopup)
   - [`webextensions.api.pageAction.setTitle`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/setTitle)
   - [`webextensions.api.permissions.Permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/Permissions)
@@ -514,7 +1191,7 @@
   - [`webextensions.api.permissions.onRemoved`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved)
   - [`webextensions.api.permissions.remove`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove)
   - [`webextensions.api.permissions.request`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request)
-  - [`webextensions.api.runtime.MessageSender`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender)
+  - [`webextensions.api.runtime.MessageSender`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender) +1 +1 +1 +1
   - [`webextensions.api.runtime.OnInstalledReason`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason)
   - [`webextensions.api.runtime.PlatformArch`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch)
   - [`webextensions.api.runtime.PlatformInfo`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformInfo)
@@ -530,13 +1207,15 @@
   - [`webextensions.api.runtime.lastError`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError)
   - [`webextensions.api.runtime.onConnect`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnect)
   - [`webextensions.api.runtime.onInstalled`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled)
+  - `webextensions.api.runtime.onInstalled.details.previousVersion`
+  - `webextensions.api.runtime.onInstalled.details.reason`
   - [`webextensions.api.runtime.onMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)
   - [`webextensions.api.runtime.onStartup`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onStartup)
   - [`webextensions.api.runtime.openOptionsPage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage)
   - [`webextensions.api.runtime.reload`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/reload)
   - [`webextensions.api.runtime.sendMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage)
   - [`webextensions.api.runtime.sendNativeMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage)
-  - [`webextensions.api.storage.StorageArea`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea)
+  - [`webextensions.api.storage.StorageArea`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea) +1 +1 +1 +1 +1
   - [`webextensions.api.storage.StorageChange`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageChange)
   - [`webextensions.api.storage.local`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local)
   - [`webextensions.api.storage.onChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged)
@@ -560,10 +1239,11 @@
   - [`webextensions.api.tabs.WindowType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/WindowType)
   - [`webextensions.api.tabs.captureVisibleTab`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab)
   - [`webextensions.api.tabs.connect`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect)
-  - [`webextensions.api.tabs.create`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create)
+  - `webextensions.api.tabs.connect.connectInfo.frameId`
+  - [`webextensions.api.tabs.create`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create) +1 +1 +1 +1 +1
   - [`webextensions.api.tabs.detectLanguage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage)
   - [`webextensions.api.tabs.duplicate`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate)
-  - [`webextensions.api.tabs.executeScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript)
+  - [`webextensions.api.tabs.executeScript`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript) +1
   - [`webextensions.api.tabs.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get)
   - [`webextensions.api.tabs.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent)
   - [`webextensions.api.tabs.getZoom`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom)
@@ -578,13 +1258,29 @@
   - [`webextensions.api.tabs.onMoved`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved)
   - [`webextensions.api.tabs.onRemoved`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved)
   - [`webextensions.api.tabs.onUpdated`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated)
+  - `webextensions.api.tabs.onUpdated.changeInfo.audible`
+  - `webextensions.api.tabs.onUpdated.changeInfo.status`
+  - `webextensions.api.tabs.onUpdated.changeInfo.title`
+  - `webextensions.api.tabs.onUpdated.changeInfo.url`
   - [`webextensions.api.tabs.query`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query)
+  - `webextensions.api.tabs.query.queryInfo.active`
+  - `webextensions.api.tabs.query.queryInfo.audible`
+  - `webextensions.api.tabs.query.queryInfo.currentWindow`
+  - `webextensions.api.tabs.query.queryInfo.highlighted`
+  - `webextensions.api.tabs.query.queryInfo.index`
+  - `webextensions.api.tabs.query.queryInfo.lastFocusedWindow`
+  - `webextensions.api.tabs.query.queryInfo.openerTabId`
+  - `webextensions.api.tabs.query.queryInfo.status`
+  - `webextensions.api.tabs.query.queryInfo.title`
+  - `webextensions.api.tabs.query.queryInfo.url`
+  - `webextensions.api.tabs.query.queryInfo.windowId`
+  - `webextensions.api.tabs.query.queryInfo.windowType`
   - [`webextensions.api.tabs.reload`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload)
   - [`webextensions.api.tabs.remove`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove)
   - [`webextensions.api.tabs.removeCSS`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS)
   - [`webextensions.api.tabs.sendMessage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage)
   - [`webextensions.api.tabs.setZoom`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom)
-  - [`webextensions.api.tabs.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update)
+  - [`webextensions.api.tabs.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update) +1 +1 +1
   - [`webextensions.api.webNavigation.getAllFrames`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames)
   - [`webextensions.api.webNavigation.getFrame`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame)
   - [`webextensions.api.webNavigation.onBeforeNavigate`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate)
@@ -595,36 +1291,39 @@
   - [`webextensions.api.windows.CreateType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/CreateType)
   - [`webextensions.api.windows.WINDOW_ID_CURRENT`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT)
   - [`webextensions.api.windows.WINDOW_ID_NONE`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE)
-  - [`webextensions.api.windows.Window`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window)
+  - [`webextensions.api.windows.Window`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
   - [`webextensions.api.windows.WindowType`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/WindowType)
-  - [`webextensions.api.windows.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get)
-  - [`webextensions.api.windows.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll)
-  - [`webextensions.api.windows.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent)
-  - [`webextensions.api.windows.getLastFocused`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused)
+  - [`webextensions.api.windows.get`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get) +1
+  - [`webextensions.api.windows.getAll`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getAll) +1
+  - [`webextensions.api.windows.getCurrent`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent) +1
+  - [`webextensions.api.windows.getLastFocused`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getLastFocused) +1
   - [`webextensions.api.windows.onCreated`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onCreated)
   - [`webextensions.api.windows.onFocusChanged`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/onFocusChanged)
-  - [`webextensions.api.windows.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update)
+  - [`webextensions.api.windows.update`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/update) +1
   - [`webextensions.manifest.author`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author)
-  - [`webextensions.manifest.background`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background)
-  - [`webextensions.manifest.browser_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action)
-  - [`webextensions.manifest.chrome_url_overrides`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
+  - [`webextensions.manifest.background`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background) +1 +1
+  - [`webextensions.manifest.browser_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) +1 +1 +1
+  - [`webextensions.manifest.chrome_url_overrides`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides) +1
   - [`webextensions.manifest.commands`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands)
-  - [`webextensions.manifest.content_scripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts)
+  - [`webextensions.manifest.content_scripts`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) +1 +1 +1 +1 +1 +1
   - [`webextensions.manifest.content_security_policy`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy)
   - [`webextensions.manifest.default_locale`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/default_locale)
   - [`webextensions.manifest.description`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description)
   - [`webextensions.manifest.homepage_url`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url)
   - [`webextensions.manifest.icons`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons)
-  - [`webextensions.manifest.manifest_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version)
+  - [`webextensions.manifest.manifest_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version) +1
   - [`webextensions.manifest.name`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name)
-  - [`webextensions.manifest.optional_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions)
-  - [`webextensions.manifest.options_ui`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui)
-  - [`webextensions.manifest.page_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action)
-  - [`webextensions.manifest.permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions)
+  - [`webextensions.manifest.optional_permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) +1 +1 +1 +1 +1 +1
+  - [`webextensions.manifest.options_ui`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) +1
+  - [`webextensions.manifest.page_action`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) +1 +1 +1
+  - [`webextensions.manifest.permissions`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) +1 +1 +1 +1 +1 +1 +1 +1
   - [`webextensions.manifest.short_name`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name)
   - [`webextensions.manifest.version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version)
   - [`webextensions.manifest.web_accessible_resources`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)
   - [`webextensions.match_patterns`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Match_patterns)
+  - `webextensions.match_patterns.scheme.http`
+  - `webextensions.match_patterns.scheme.https`
+  - `webextensions.match_patterns.scheme.wildcard`
 
 ## Sep 2021
 ### Browsers released:
@@ -634,15 +1333,23 @@
   - {'browser':'safari','version':'15'}
   - {'browser':'safari_ios','version':'15'}
 ### These Features became stable across all major browsers:
-  - [`api.VisualViewport`](https://developer.mozilla.org/docs/Web/API/VisualViewport)
+  - [`api.VisualViewport`](https://developer.mozilla.org/docs/Web/API/VisualViewport) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.Window.visualViewport`](https://developer.mozilla.org/docs/Web/API/Window/visualViewport)
   - [`css.properties.tab-size`](https://developer.mozilla.org/docs/Web/CSS/tab-size)
+  - [`javascript.builtins.Intl.DateTimeFormat.formatRange`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange)
+  - [`javascript.builtins.Intl.DateTimeFormat.formatRangeToParts`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRangeToParts)
 
 ## Aug 2021
 ### Browsers released:
   - {'browser':'chrome','version':'93'}
   - {'browser':'firefox','version':'91'}
 ### These Features became stable across all major browsers:
+  - `api.WheelEvent.wheelDelta`
+  - `api.WheelEvent.wheelDeltaX`
+  - `api.WheelEvent.wheelDeltaY`
   - [`css.properties.scroll-margin`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin)
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_dayPeriod_parameter`
+  - [`javascript.classes.private_class_fields`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
 
 ## Jul 2021
 ### Browsers released:
@@ -651,6 +1358,10 @@
   - {'browser':'firefox','version':'90'}
 
 ## Jun 2021
+### These Features became stable across all major browsers:
+  - [`api.RTCStatsReport.type_remote-outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_outbound_rtp) +1 +1
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.IntlLegacyConstructedSymbol`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.IntlLegacyConstructedSymbol`
 
 ## May 2021
 ### Browsers released:
@@ -658,26 +1369,77 @@
   - {'browser':'edge','version':'91'}
   - {'browser':'firefox','version':'89'}
 ### These Features became stable across all major browsers:
-  - [`api.AbstractRange`](https://developer.mozilla.org/docs/Web/API/AbstractRange)
-  - [`api.AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext)
-  - [`api.AudioParamMap`](https://developer.mozilla.org/docs/Web/API/AudioParamMap)
+  - [`api.AbstractRange`](https://developer.mozilla.org/docs/Web/API/AbstractRange) +1 +1 +1 +1 +1
+  - [`api.AnalyserNode.AnalyserNode`](https://developer.mozilla.org/docs/Web/API/AnalyserNode/AnalyserNode)
+  - [`api.AnalyserNode.getFloatTimeDomainData`](https://developer.mozilla.org/docs/Web/API/AnalyserNode/getFloatTimeDomainData)
+  - [`api.AudioBuffer.AudioBuffer`](https://developer.mozilla.org/docs/Web/API/AudioBuffer/AudioBuffer)
+  - [`api.AudioBuffer.copyFromChannel`](https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyFromChannel)
+  - [`api.AudioBuffer.copyToChannel`](https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyToChannel)
+  - [`api.AudioBufferSourceNode.AudioBufferSourceNode`](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/AudioBufferSourceNode)
+  - [`api.AudioBufferSourceNode.detune`](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/detune)
+  - [`api.AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext) +1
+  - `api.AudioContext.AudioContext.options_sampleRate_parameter` +1 +1
+  - [`api.AudioDestinationNode.maxChannelCount`](https://developer.mozilla.org/docs/Web/API/AudioDestinationNode/maxChannelCount)
+  - [`api.AudioParamMap`](https://developer.mozilla.org/docs/Web/API/AudioParamMap) +1 +1 +1 +1 +1 +1 +1 +1
   - [`api.AudioWorklet`](https://developer.mozilla.org/docs/Web/API/AudioWorklet)
-  - [`api.AudioWorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/AudioWorkletGlobalScope)
-  - [`api.AudioWorkletNode`](https://developer.mozilla.org/docs/Web/API/AudioWorkletNode)
-  - [`api.AudioWorkletProcessor`](https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor)
-  - [`api.BaseAudioContext`](https://developer.mozilla.org/docs/Web/API/BaseAudioContext)
-  - [`api.CSSConditionRule`](https://developer.mozilla.org/docs/Web/API/CSSConditionRule)
+  - [`api.AudioWorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/AudioWorkletGlobalScope) +1 +1 +1 +1
+  - [`api.AudioWorkletNode`](https://developer.mozilla.org/docs/Web/API/AudioWorkletNode) +1 +1 +1 +1
+  - [`api.AudioWorkletProcessor`](https://developer.mozilla.org/docs/Web/API/AudioWorkletProcessor) +1 +1
+  - [`api.BaseAudioContext`](https://developer.mozilla.org/docs/Web/API/BaseAudioContext) +1 +1 +1 +1
+  - `api.BaseAudioContext.decodeAudioData.returns_promise`
+  - [`api.BiquadFilterNode.BiquadFilterNode`](https://developer.mozilla.org/docs/Web/API/BiquadFilterNode/BiquadFilterNode)
+  - [`api.Blob.stream`](https://developer.mozilla.org/docs/Web/API/Blob/stream)
+  - [`api.CSSConditionRule`](https://developer.mozilla.org/docs/Web/API/CSSConditionRule) +1
   - [`api.CSSGroupingRule`](https://developer.mozilla.org/docs/Web/API/CSSGroupingRule)
-  - [`api.ConstantSourceNode`](https://developer.mozilla.org/docs/Web/API/ConstantSourceNode)
-  - [`api.IIRFilterNode`](https://developer.mozilla.org/docs/Web/API/IIRFilterNode)
-  - [`api.MediaRecorder`](https://developer.mozilla.org/docs/Web/API/MediaRecorder)
+  - [`api.ChannelMergerNode.ChannelMergerNode`](https://developer.mozilla.org/docs/Web/API/ChannelMergerNode/ChannelMergerNode)
+  - [`api.ChannelSplitterNode.ChannelSplitterNode`](https://developer.mozilla.org/docs/Web/API/ChannelSplitterNode/ChannelSplitterNode)
+  - [`api.ConstantSourceNode`](https://developer.mozilla.org/docs/Web/API/ConstantSourceNode) +1 +1
+  - [`api.ConvolverNode.ConvolverNode`](https://developer.mozilla.org/docs/Web/API/ConvolverNode/ConvolverNode)
+  - [`api.DataTransfer.DataTransfer`](https://developer.mozilla.org/docs/Web/API/DataTransfer/DataTransfer)
+  - [`api.DelayNode.DelayNode`](https://developer.mozilla.org/docs/Web/API/DelayNode/DelayNode)
+  - [`api.Document.visibilitychange_event`](https://developer.mozilla.org/docs/Web/API/Document/visibilitychange_event)
+  - [`api.DynamicsCompressorNode.DynamicsCompressorNode`](https://developer.mozilla.org/docs/Web/API/DynamicsCompressorNode/DynamicsCompressorNode)
+  - [`api.GainNode.GainNode`](https://developer.mozilla.org/docs/Web/API/GainNode/GainNode)
+  - [`api.HTMLAreaElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy)
+  - [`api.HTMLLinkElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/referrerPolicy)
+  - [`api.IIRFilterNode`](https://developer.mozilla.org/docs/Web/API/IIRFilterNode) +1 +1
+  - [`api.MediaElementAudioSourceNode.MediaElementAudioSourceNode`](https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode)
+  - [`api.MediaRecorder`](https://developer.mozilla.org/docs/Web/API/MediaRecorder) +1
+  - `api.MediaRecorder.MediaRecorder.options_parameter` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode)
+  - [`api.MediaStreamAudioSourceNode.MediaStreamAudioSourceNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceNode/MediaStreamAudioSourceNode)
   - [`api.OES_fbo_render_mipmap`](https://developer.mozilla.org/docs/Web/API/OES_fbo_render_mipmap)
-  - [`api.OfflineAudioContext`](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext)
+  - [`api.OfflineAudioContext`](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext) +1 +1
+  - [`api.OscillatorNode.OscillatorNode`](https://developer.mozilla.org/docs/Web/API/OscillatorNode/OscillatorNode)
+  - [`api.PannerNode.PannerNode`](https://developer.mozilla.org/docs/Web/API/PannerNode/PannerNode)
+  - [`api.PannerNode.orientationX`](https://developer.mozilla.org/docs/Web/API/PannerNode/orientationX)
+  - [`api.PannerNode.orientationY`](https://developer.mozilla.org/docs/Web/API/PannerNode/orientationY)
+  - [`api.PannerNode.orientationZ`](https://developer.mozilla.org/docs/Web/API/PannerNode/orientationZ)
+  - [`api.PannerNode.positionX`](https://developer.mozilla.org/docs/Web/API/PannerNode/positionX)
+  - [`api.PannerNode.positionY`](https://developer.mozilla.org/docs/Web/API/PannerNode/positionY)
+  - [`api.PannerNode.positionZ`](https://developer.mozilla.org/docs/Web/API/PannerNode/positionZ)
+  - [`api.Performance.toJSON`](https://developer.mozilla.org/docs/Web/API/Performance/toJSON)
+  - [`api.PerformanceNavigation.toJSON`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigation/toJSON)
   - [`api.PerformancePaintTiming`](https://developer.mozilla.org/docs/Web/API/PerformancePaintTiming)
-  - [`api.StereoPannerNode`](https://developer.mozilla.org/docs/Web/API/StereoPannerNode)
+  - [`api.PeriodicWave.PeriodicWave`](https://developer.mozilla.org/docs/Web/API/PeriodicWave/PeriodicWave)
+  - [`api.RTCIceCandidate.usernameFragment`](https://developer.mozilla.org/docs/Web/API/RTCIceCandidate/usernameFragment)
+  - [`api.RTCPeerConnection.restartIce`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/restartIce)
+  - `api.RTCPeerConnection.setLocalDescription.description_parameter_optional`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.id`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.localId`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.timestamp`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.type`
+  - [`api.Request.formData`](https://developer.mozilla.org/docs/Web/API/Request/formData)
+  - [`api.Response.formData`](https://developer.mozilla.org/docs/Web/API/Response/formData)
+  - [`api.StaticRange.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange/StaticRange)
+  - [`api.StereoPannerNode`](https://developer.mozilla.org/docs/Web/API/StereoPannerNode) +1 +1
+  - [`api.TextEncoder.encodeInto`](https://developer.mozilla.org/docs/Web/API/TextEncoder/encodeInto)
+  - [`api.URL.URL`](https://developer.mozilla.org/docs/Web/API/URL/URL)
   - [`api.WEBGL_compressed_texture_s3tc_srgb`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_s3tc_srgb)
-  - [`api.Worklet`](https://developer.mozilla.org/docs/Web/API/Worklet)
-  - `api.WorkletGlobalScope`
+  - [`api.WaveShaperNode.WaveShaperNode`](https://developer.mozilla.org/docs/Web/API/WaveShaperNode/WaveShaperNode)
+  - [`api.Worklet`](https://developer.mozilla.org/docs/Web/API/Worklet) +1
+  - [`api.WorkletGlobalScope`](https://developer.mozilla.org/docs/Web/API/WorkletGlobalScope)
+  - `css.at-rules.supports.selector`
   - [`css.properties.border-block`](https://developer.mozilla.org/docs/Web/CSS/border-block)
   - [`css.properties.border-block-color`](https://developer.mozilla.org/docs/Web/CSS/border-block-color)
   - [`css.properties.border-block-style`](https://developer.mozilla.org/docs/Web/CSS/border-block-style)
@@ -686,6 +1448,9 @@
   - [`css.properties.border-inline-color`](https://developer.mozilla.org/docs/Web/CSS/border-inline-color)
   - [`css.properties.border-inline-style`](https://developer.mozilla.org/docs/Web/CSS/border-inline-style)
   - [`css.properties.border-inline-width`](https://developer.mozilla.org/docs/Web/CSS/border-inline-width)
+  - `css.properties.column-gap.flex_context`
+  - `css.properties.gap.flex_context`
+  - `css.properties.gap.multicol_context`
   - [`css.properties.inset`](https://developer.mozilla.org/docs/Web/CSS/inset)
   - [`css.properties.inset-block`](https://developer.mozilla.org/docs/Web/CSS/inset-block)
   - [`css.properties.inset-block-end`](https://developer.mozilla.org/docs/Web/CSS/inset-block-end)
@@ -693,10 +1458,13 @@
   - [`css.properties.inset-inline`](https://developer.mozilla.org/docs/Web/CSS/inset-inline)
   - [`css.properties.inset-inline-end`](https://developer.mozilla.org/docs/Web/CSS/inset-inline-end)
   - [`css.properties.inset-inline-start`](https://developer.mozilla.org/docs/Web/CSS/inset-inline-start)
+  - `css.properties.list-style-type.string`
   - [`css.properties.margin-block`](https://developer.mozilla.org/docs/Web/CSS/margin-block)
   - [`css.properties.margin-inline`](https://developer.mozilla.org/docs/Web/CSS/margin-inline)
   - [`css.properties.padding-block`](https://developer.mozilla.org/docs/Web/CSS/padding-block)
   - [`css.properties.padding-inline`](https://developer.mozilla.org/docs/Web/CSS/padding-inline)
+  - `css.properties.quotes.auto`
+  - `css.properties.row-gap.flex_context`
   - [`css.properties.scroll-margin-bottom`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom)
   - [`css.properties.scroll-margin-left`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left)
   - [`css.properties.scroll-margin-right`](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right)
@@ -707,8 +1475,28 @@
   - [`css.properties.scroll-padding-right`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right)
   - [`css.properties.scroll-padding-top`](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top)
   - [`css.selectors.file-selector-button`](https://developer.mozilla.org/docs/Web/CSS/::file-selector-button)
-  - [`javascript.builtins.FinalizationRegistry`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry)
-  - [`javascript.builtins.WeakRef`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef)
+  - [`html.elements.input.type_date`](https://developer.mozilla.org/docs/Web/HTML/Element/input/date)
+  - [`html.elements.input.type_time`](https://developer.mozilla.org/docs/Web/HTML/Element/input/time)
+  - [`javascript.builtins.FinalizationRegistry`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) +1 +1 +1
+  - `javascript.builtins.Intl.Collator.Collator.options_collation_parameter`
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_calendar_parameter`
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_dateStyle_parameter`
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_fractionalSecondDigits_parameter`
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_numberingSystem_parameter`
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_timeStyle_parameter`
+  - [`javascript.builtins.Intl.DisplayNames`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) +1 +1 +1 +1
+  - [`javascript.builtins.Intl.ListFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) +1 +1 +1 +1 +1
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_compactDisplay_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_currencyDisplay_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_currencySign_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_notation_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_signDisplay_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_unitDisplay_parameter`
+  - `javascript.builtins.Intl.NumberFormat.NumberFormat.options_parameter.options_unit_parameter`
+  - [`javascript.builtins.WeakRef`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) +1 +1
+  - [`javascript.classes.public_class_fields`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_fields)
+  - [`javascript.classes.static_class_fields`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_fields)
+  - [`javascript.statements.export.namespace`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export)
   - `webassembly.BigInt-to-i64-integration`
 
 ## Apr 2021
@@ -719,6 +1507,9 @@
   - {'browser':'safari','version':'14.1'}
   - {'browser':'safari_ios','version':'14.5'}
 ### These Features became stable across all major browsers:
+  - [`api.Element.beforeinput_event`](https://developer.mozilla.org/docs/Web/API/Element/beforeinput_event)
+  - [`api.InputEvent.getTargetRanges`](https://developer.mozilla.org/docs/Web/API/InputEvent/getTargetRanges)
+  - [`api.MediaSource.sourceclose_event`](https://developer.mozilla.org/docs/Web/API/MediaSource/sourceclose_event)
   - [`css.properties.text-decoration-thickness`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness)
 
 ## Mar 2021
@@ -726,14 +1517,24 @@
   - {'browser':'chrome','version':'89'}
   - {'browser':'edge','version':'89'}
   - {'browser':'firefox','version':'87'}
+### These Features became stable across all major browsers:
+  - `svg.elements.feComposite.operator.lighter_value`
 
 ## Feb 2021
 ### Browsers released:
   - {'browser':'firefox','version':'86'}
 ### These Features became stable across all major browsers:
-  - [`css.selectors.is`](https://developer.mozilla.org/docs/Web/CSS/:is)
-  - [`css.selectors.where`](https://developer.mozilla.org/docs/Web/CSS/:where)
-  - [`http.headers.Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy)
+  - [`api.RTCRtpTransceiver.stop`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/stop)
+  - `css.properties.clip-path.path`
+  - `css.properties.hyphens.auto`
+  - `css.properties.touch-action.pinch-zoom`
+  - [`css.selectors.is`](https://developer.mozilla.org/docs/Web/CSS/:is) +1
+  - `css.selectors.not.selector_list`
+  - [`css.selectors.where`](https://developer.mozilla.org/docs/Web/CSS/:where) +1
+  - [`css.types.basic-shape.path.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path)
+  - `html.elements.a.implicit_noopener`
+  - `html.elements.area.implicit_noopener`
+  - [`http.headers.Permissions-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy) +1 +1
 
 ## Jan 2021
 ### Browsers released:
@@ -751,7 +1552,21 @@
 ### Browsers released:
   - {'browser':'firefox','version':'84'}
 ### These Features became stable across all major browsers:
-  - [`css.properties.text-underline-offset`](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset)
+  - [`api.Element.transitioncancel_event`](https://developer.mozilla.org/docs/Web/API/Element/transitioncancel_event)
+  - `css.properties.hyphens.language_croatian`
+  - `css.properties.hyphens.language_danish`
+  - `css.properties.hyphens.language_french`
+  - `css.properties.hyphens.language_german_reformed_orthography`
+  - `css.properties.hyphens.language_hungarian`
+  - `css.properties.hyphens.language_norwegian_no`
+  - `css.properties.hyphens.language_portuguese`
+  - `css.properties.hyphens.language_spanish`
+  - `css.properties.text-decoration-thickness.auto`
+  - `css.properties.text-decoration-thickness.from-font`
+  - [`css.properties.text-underline-offset`](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset) +1
+  - `css.properties.text-underline-position.from-font`
+  - [`css.types.image.gradient.conic-gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient) +1
+  - [`css.types.image.gradient.repeating-conic-gradient`](https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient)
 
 ## Nov 2020
 ### Browsers released:
@@ -759,7 +1574,11 @@
   - {'browser':'edge','version':'87'}
   - {'browser':'firefox','version':'83'}
 ### These Features became stable across all major browsers:
-  - [`api.MediaMetadata`](https://developer.mozilla.org/docs/Web/API/MediaMetadata)
+  - [`api.Document.replaceChildren`](https://developer.mozilla.org/docs/Web/API/Document/replaceChildren)
+  - [`api.DocumentFragment.replaceChildren`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/replaceChildren)
+  - [`api.Element.replaceChildren`](https://developer.mozilla.org/docs/Web/API/Element/replaceChildren)
+  - [`api.Element.scrollLeft`](https://developer.mozilla.org/docs/Web/API/Element/scrollLeft)
+  - [`api.MediaMetadata`](https://developer.mozilla.org/docs/Web/API/MediaMetadata) +1 +1 +1 +1 +1
   - [`css.selectors.marker`](https://developer.mozilla.org/docs/Web/CSS/::marker)
 
 ## Oct 2020
@@ -769,23 +1588,71 @@
   - {'browser':'firefox','version':'82'}
 ### These Features became stable across all major browsers:
   - [`api.AudioScheduledSourceNode`](https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode)
-  - [`api.BlobEvent`](https://developer.mozilla.org/docs/Web/API/BlobEvent)
+  - [`api.Blob.arrayBuffer`](https://developer.mozilla.org/docs/Web/API/Blob/arrayBuffer)
+  - [`api.Blob.text`](https://developer.mozilla.org/docs/Web/API/Blob/text)
+  - [`api.BlobEvent`](https://developer.mozilla.org/docs/Web/API/BlobEvent) +1 +1
+  - [`api.Document.getAnimations`](https://developer.mozilla.org/docs/Web/API/Document/getAnimations)
+  - [`api.DragEvent`](https://developer.mozilla.org/docs/Web/API/DragEvent) +1 +1
   - [`api.EXT_color_buffer_half_float`](https://developer.mozilla.org/docs/Web/API/EXT_color_buffer_half_float)
-  - [`api.MediaQueryListEvent`](https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent)
-  - [`api.WEBGL_debug_shaders`](https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders)
+  - `api.Element.animate.options_pseudoElement_parameter`
+  - `api.Element.scroll.options_behavior_parameter`
+  - `api.Element.scrollBy.options_behavior_parameter`
+  - `api.Element.scrollIntoView.options_parameter`
+  - `api.Element.scrollTo.options_behavior_parameter`
+  - [`api.EventTarget.EventTarget`](https://developer.mozilla.org/docs/Web/API/EventTarget/EventTarget)
+  - [`api.HTMLAnchorElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/referrerPolicy)
+  - [`api.HTMLIFrameElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/referrerPolicy)
+  - [`api.HTMLImageElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/referrerPolicy)
+  - [`api.HTMLScriptElement.referrerPolicy`](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/referrerPolicy)
+  - [`api.KeyframeEffect.pseudoElement`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/pseudoElement)
+  - `api.MediaQueryList.EventTarget_inheritance`
+  - [`api.MediaQueryList.change_event`](https://developer.mozilla.org/docs/Web/API/MediaQueryList/change_event)
+  - [`api.MediaQueryListEvent`](https://developer.mozilla.org/docs/Web/API/MediaQueryListEvent) +1 +1 +1
+  - [`api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent`](https://developer.mozilla.org/docs/Web/API/OfflineAudioCompletionEvent/OfflineAudioCompletionEvent)
+  - `api.RTCStatsReport.type_inbound-rtp.kind`
+  - `api.RTCStatsReport.type_outbound-rtp.kind`
+  - `api.RTCStatsReport.type_remote-inbound-rtp.kind`
+  - [`api.ShadowRoot.getAnimations`](https://developer.mozilla.org/docs/Web/API/ShadowRoot/getAnimations)
+  - [`api.URLSearchParams.delete`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete)
+  - [`api.WEBGL_debug_shaders`](https://developer.mozilla.org/docs/Web/API/WEBGL_debug_shaders) +1
+  - `api.Window.scroll.options_behavior_parameter`
+  - `api.Window.scrollBy.options_behavior_parameter`
+  - `api.Window.scrollTo.options_behavior_parameter`
+  - `css.properties.animation-timing-function.jump`
   - [`css.properties.flex-direction`](https://developer.mozilla.org/docs/Web/CSS/flex-direction)
   - [`css.properties.text-orientation`](https://developer.mozilla.org/docs/Web/CSS/text-orientation)
-  - [`javascript.builtins.AggregateError`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError)
-  - [`javascript.builtins.BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
+  - `css.properties.transition-timing-function.jump`
+  - `css.types.easing-function.steps.jump`
+  - `html.elements.a.referrerpolicy`
+  - `html.elements.area.referrerpolicy`
+  - `html.elements.iframe.referrerpolicy`
+  - `html.elements.img.referrerpolicy`
+  - `html.elements.link.referrerpolicy`
+  - `html.elements.video.aspect_ratio_computed_from_attributes`
+  - `http.headers.Referer.length_limit_4096B`
+  - [`javascript.builtins.AggregateError`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) +1 +1
+  - [`javascript.builtins.BigInt`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt) +1 +1 +1 +1
+  - `javascript.builtins.BigInt.toLocaleString.locales_parameter`
+  - `javascript.builtins.BigInt.toLocaleString.options_parameter` +1 +1
+  - [`javascript.builtins.Intl.Locale`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`javascript.builtins.Intl.RelativeTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) +1 +1 +1 +1
+  - `javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions.numberingSystem` +1
+  - [`javascript.builtins.Promise.any`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
+  - [`javascript.builtins.Symbol.toStringTag.dom_objects`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects)
   - [`javascript.operators.logical_and_assignment`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment)
   - [`javascript.operators.logical_or_assignment`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment)
   - [`javascript.operators.nullish_coalescing_assignment`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment)
+  - `svg.elements.a.referrerpolicy`
+  - [`svg.elements.stop.stop-opacity`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stop-opacity)
 
 ## Sep 2020
 ### Browsers released:
   - {'browser':'firefox','version':'81'}
   - {'browser':'safari','version':'14'}
   - {'browser':'safari_ios','version':'14'}
+### These Features became stable across all major browsers:
+  - `css.properties.appearance.menulist-button`
+  - [`javascript.builtins.String.replaceAll`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll)
 
 ## Aug 2020
 ### Browsers released:
@@ -793,12 +1660,30 @@
   - {'browser':'edge','version':'85'}
   - {'browser':'firefox','version':'80'}
 ### These Features became stable across all major browsers:
-  - [`api.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent)
-  - [`api.AnimationTimeline`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline)
-  - [`api.CSSAnimation`](https://developer.mozilla.org/docs/Web/API/CSSAnimation)
-  - [`api.CSSTransition`](https://developer.mozilla.org/docs/Web/API/CSSTransition)
-  - [`api.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline)
+  - [`api.Animation.commitStyles`](https://developer.mozilla.org/docs/Web/API/Animation/commitStyles)
+  - [`api.Animation.finished`](https://developer.mozilla.org/docs/Web/API/Animation/finished)
+  - [`api.Animation.persist`](https://developer.mozilla.org/docs/Web/API/Animation/persist)
+  - [`api.Animation.ready`](https://developer.mozilla.org/docs/Web/API/Animation/ready)
+  - [`api.Animation.remove_event`](https://developer.mozilla.org/docs/Web/API/Animation/remove_event)
+  - [`api.Animation.remove_filling_animation`](https://developer.mozilla.org/docs/web/api/web_animations_api/using_the_web_animations_api#automatically_removing_filling_animations)
+  - [`api.Animation.replaceState`](https://developer.mozilla.org/docs/Web/API/Animation/replaceState)
+  - [`api.Animation.timeline`](https://developer.mozilla.org/docs/Web/API/Animation/timeline)
+  - [`api.AnimationPlaybackEvent`](https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent) +1 +1 +1
+  - [`api.AnimationTimeline`](https://developer.mozilla.org/docs/Web/API/AnimationTimeline) +1
+  - [`api.CSSAnimation`](https://developer.mozilla.org/docs/Web/API/CSSAnimation) +1
+  - [`api.CSSTransition`](https://developer.mozilla.org/docs/Web/API/CSSTransition) +1
+  - `api.CanvasPattern.setTransform.dommatrix`
+  - [`api.Document.timeline`](https://developer.mozilla.org/docs/Web/API/Document/timeline)
+  - [`api.DocumentTimeline`](https://developer.mozilla.org/docs/Web/API/DocumentTimeline) +1
+  - [`api.Element.animate.implicit_tofrom`](https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes)
+  - [`api.Element.getAnimations`](https://developer.mozilla.org/docs/Web/API/Element/getAnimations)
+  - [`api.FileReader.loadstart_event`](https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event)
+  - [`api.KeyframeEffect.getKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/getKeyframes)
+  - [`api.KeyframeEffect.setKeyframes`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes)
+  - [`api.RTCStatsReport.type_data-channel`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#data_channel) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
   - [`css.properties.ruby-position`](https://developer.mozilla.org/docs/Web/CSS/ruby-position)
+  - [`css.types.global_keywords.revert`](https://developer.mozilla.org/docs/Web/CSS/revert)
+  - `html.elements.iframe.sandbox.allow-top-navigation-by-user-activation`
 
 ## Jul 2020
 ### Browsers released:
@@ -808,14 +1693,19 @@
 ### These Features became stable across all major browsers:
   - [`css.selectors.read-only`](https://developer.mozilla.org/docs/Web/CSS/:read-only)
   - [`css.selectors.read-write`](https://developer.mozilla.org/docs/Web/CSS/:read-write)
+  - [`javascript.builtins.RegExp.dotAll`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll)
   - [`javascript.regular_expressions.named_backreference`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference)
   - [`javascript.regular_expressions.named_capturing_group`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)
   - [`javascript.regular_expressions.unicode_character_class_escape`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape)
-  - [`svg.attributes.presentation.transform-origin`](https://developer.mozilla.org/docs/Web/SVG/Attribute/transform-origin)
+  - [`svg.global_attributes.transform-origin`](https://developer.mozilla.org/docs/Web/SVG/Attribute/transform-origin)
 
 ## Jun 2020
 ### Browsers released:
   - {'browser':'firefox','version':'78'}
+### These Features became stable across all major browsers:
+  - [`api.Element.animationcancel_event`](https://developer.mozilla.org/docs/Web/API/Element/animationcancel_event)
+  - [`css.properties.grid-template-columns.repeat`](https://developer.mozilla.org/docs/Web/CSS/repeat())
+  - [`css.properties.grid-template-rows.repeat`](https://developer.mozilla.org/docs/Web/CSS/repeat())
 
 ## May 2020
 ### Browsers released:
@@ -823,11 +1713,12 @@
   - {'browser':'edge','version':'83'}
   - {'browser':'firefox','version':'76'}
 ### These Features became stable across all major browsers:
-  - [`css.properties.image-orientation`](https://developer.mozilla.org/docs/Web/CSS/image-orientation)
+  - [`api.ServiceWorkerGlobalScope.messageerror_event`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/messageerror_event)
+  - [`css.properties.image-orientation`](https://developer.mozilla.org/docs/Web/CSS/image-orientation) +1 +1
   - [`css.types.clamp`](https://developer.mozilla.org/docs/Web/CSS/clamp)
   - [`css.types.max`](https://developer.mozilla.org/docs/Web/CSS/max)
   - [`css.types.min`](https://developer.mozilla.org/docs/Web/CSS/min)
-  - [`svg.attributes.conditional_processing.requiredExtensions`](https://developer.mozilla.org/docs/Web/SVG/Attribute/requiredExtensions)
+  - [`svg.global_attributes.requiredExtensions`](https://developer.mozilla.org/docs/Web/SVG/Attribute/requiredExtensions)
 
 ## Apr 2020
 ### Browsers released:
@@ -835,25 +1726,72 @@
   - {'browser':'edge','version':'81'}
   - {'browser':'firefox','version':'75'}
 ### These Features became stable across all major browsers:
-  - [`api.Animation`](https://developer.mozilla.org/docs/Web/API/Animation)
-  - [`api.AnimationEffect`](https://developer.mozilla.org/docs/Web/API/AnimationEffect)
-  - [`api.Clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard)
+  - [`api.Animation`](https://developer.mozilla.org/docs/Web/API/Animation) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.AnimationEffect`](https://developer.mozilla.org/docs/Web/API/AnimationEffect) +1 +1 +1
+  - [`api.AnimationEvent.pseudoElement`](https://developer.mozilla.org/docs/Web/API/AnimationEvent/pseudoElement)
+  - [`api.Clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard) +1
+  - [`api.Element.animate`](https://developer.mozilla.org/docs/Web/API/Element/animate) +1
+  - [`api.Element.part`](https://developer.mozilla.org/docs/Web/API/Element/part)
+  - [`api.Element.transitionrun_event`](https://developer.mozilla.org/docs/Web/API/Element/transitionrun_event)
+  - [`api.Element.transitionstart_event`](https://developer.mozilla.org/docs/Web/API/Element/transitionstart_event)
+  - `api.FormData.worker_support`
   - [`api.GeolocationCoordinates`](https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates)
   - [`api.GeolocationPosition`](https://developer.mozilla.org/docs/Web/API/GeolocationPosition)
   - [`api.GeolocationPositionError`](https://developer.mozilla.org/docs/Web/API/GeolocationPositionError)
-  - [`api.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect)
-  - [`api.RTCDTMFSender`](https://developer.mozilla.org/docs/Web/API/RTCDTMFSender)
-  - [`api.RTCDTMFToneChangeEvent`](https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent)
-  - [`api.ResizeObserver`](https://developer.mozilla.org/docs/Web/API/ResizeObserver)
-  - [`api.ResizeObserverEntry`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry)
-  - [`css.properties.text-underline-position`](https://developer.mozilla.org/docs/Web/CSS/text-underline-position)
+  - `api.HTMLIFrameElement.allow`
+  - [`api.KeyframeEffect`](https://developer.mozilla.org/docs/Web/API/KeyframeEffect) +1 +1
+  - [`api.Navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Navigator/clipboard)
+  - [`api.RTCDTMFSender`](https://developer.mozilla.org/docs/Web/API/RTCDTMFSender) +1 +1 +1
+  - [`api.RTCDTMFToneChangeEvent`](https://developer.mozilla.org/docs/Web/API/RTCDTMFToneChangeEvent) +1 +1
+  - [`api.RTCRtpSender.dtmf`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/dtmf)
+  - `api.RTCStatsReport.type_candidate-pair.id`
+  - `api.RTCStatsReport.type_candidate-pair.timestamp`
+  - `api.RTCStatsReport.type_candidate-pair.type`
+  - `api.RTCStatsReport.type_inbound-rtp.bytesReceived`
+  - `api.RTCStatsReport.type_inbound-rtp.id`
+  - `api.RTCStatsReport.type_inbound-rtp.jitter`
+  - `api.RTCStatsReport.type_inbound-rtp.packetsLost`
+  - `api.RTCStatsReport.type_inbound-rtp.packetsReceived`
+  - `api.RTCStatsReport.type_inbound-rtp.timestamp`
+  - `api.RTCStatsReport.type_inbound-rtp.type`
+  - `api.RTCStatsReport.type_local-candidate.id`
+  - `api.RTCStatsReport.type_local-candidate.timestamp`
+  - `api.RTCStatsReport.type_local-candidate.type`
+  - `api.RTCStatsReport.type_outbound-rtp.bytesSent`
+  - `api.RTCStatsReport.type_outbound-rtp.id`
+  - `api.RTCStatsReport.type_outbound-rtp.packetsSent`
+  - `api.RTCStatsReport.type_outbound-rtp.timestamp`
+  - `api.RTCStatsReport.type_outbound-rtp.type`
+  - `api.RTCStatsReport.type_remote-candidate.id`
+  - `api.RTCStatsReport.type_remote-candidate.timestamp`
+  - `api.RTCStatsReport.type_remote-candidate.type`
+  - [`api.ResizeObserver`](https://developer.mozilla.org/docs/Web/API/ResizeObserver) +1 +1 +1
+  - `api.ResizeObserver.observe.options_box_parameter` +1
+  - [`api.ResizeObserverEntry`](https://developer.mozilla.org/docs/Web/API/ResizeObserverEntry) +1 +1
+  - `api.SVGLengthList.length`
+  - `api.SVGNumberList.length`
+  - [`api.SVGPointList.length`](https://developer.mozilla.org/docs/Web/API/SVGPointList/length)
+  - `api.SVGStringList.length`
+  - `api.SVGTransformList.length`
+  - [`api.TextMetrics.actualBoundingBoxAscent`](https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxAscent)
+  - [`api.TextMetrics.actualBoundingBoxDescent`](https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxDescent)
+  - [`api.TextMetrics.actualBoundingBoxLeft`](https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxLeft)
+  - [`api.TextMetrics.actualBoundingBoxRight`](https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxRight)
+  - `css.properties.opacity.percentages`
+  - `css.properties.overflow.multiple_keywords`
+  - [`css.properties.tab-size.length`](https://developer.mozilla.org/docs/Web/CSS/length)
+  - [`css.properties.text-underline-position`](https://developer.mozilla.org/docs/Web/CSS/text-underline-position) +1
+  - `css.properties.white-space.break-spaces`
   - [`css.selectors.part`](https://developer.mozilla.org/docs/Web/CSS/::part)
+  - `css.types.length.Q`
+  - `html.elements.iframe.allow`
   - [`html.global_attributes.exportparts`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/exportparts)
   - [`html.global_attributes.part`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/part)
   - [`http.headers.Cross-Origin-Resource-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
   - [`javascript.grammar.hashbang_comments`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments)
   - [`javascript.operators.nullish_coalescing`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
   - [`javascript.operators.optional_chaining`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
+  - [`webassembly.api.Global`](https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global) +1 +1 +1
 
 ## Mar 2020
 ### Browsers released:
@@ -862,8 +1800,14 @@
   - {'browser':'safari_ios','version':'13.4'}
 ### These Features became stable across all major browsers:
   - [`api.EXT_sRGB`](https://developer.mozilla.org/docs/Web/API/EXT_sRGB)
-  - [`svg.attributes.presentation.letter-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/letter-spacing)
-  - [`svg.attributes.presentation.word-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/word-spacing)
+  - [`api.HTMLVideoElement.getVideoPlaybackQuality`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/getVideoPlaybackQuality)
+  - `api.RTCStatsReport.type_inbound-rtp.ssrc`
+  - [`api.RTCStatsReport.type_local-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#local_candidate) +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_outbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#outbound_rtp) +1
+  - [`api.RTCStatsReport.type_remote-candidate`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_candidate) +1 +1 +1 +1 +1
+  - [`api.RTCStatsReport.type_remote-inbound-rtp`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_inbound_rtp) +1
+  - [`svg.global_attributes.letter-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/letter-spacing)
+  - [`svg.global_attributes.word-spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/word-spacing)
 
 ## Feb 2020
 ### Browsers released:
@@ -871,53 +1815,240 @@
   - {'browser':'edge','version':'80'}
   - {'browser':'firefox','version':'73'}
 ### These Features became stable across all major browsers:
-  - [`api.BeforeUnloadEvent`](https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent)
-  - [`api.CanvasCaptureMediaStreamTrack`](https://developer.mozilla.org/docs/Web/API/CanvasCaptureMediaStreamTrack)
-  - [`api.CustomElementRegistry`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry)
-  - [`api.DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix)
-  - [`api.DOMMatrixReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly)
-  - [`api.DOMPoint`](https://developer.mozilla.org/docs/Web/API/DOMPoint)
-  - [`api.DOMPointReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly)
-  - [`api.DOMQuad`](https://developer.mozilla.org/docs/Web/API/DOMQuad)
-  - [`api.DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect)
+  - [`api.AudioContext.createMediaStreamDestination`](https://developer.mozilla.org/docs/Web/API/AudioContext/createMediaStreamDestination)
+  - [`api.AudioParam.maxValue`](https://developer.mozilla.org/docs/Web/API/AudioParam/maxValue)
+  - [`api.AudioParam.minValue`](https://developer.mozilla.org/docs/Web/API/AudioParam/minValue)
+  - [`api.BeforeUnloadEvent`](https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent) +1
+  - [`api.CSS.escape_static`](https://developer.mozilla.org/docs/Web/API/CSS/escape_static)
+  - [`api.CSS.supports_static`](https://developer.mozilla.org/docs/Web/API/CSS/supports_static)
+  - `api.CacheStorage.secure_context_required`
+  - [`api.CanvasPattern.setTransform`](https://developer.mozilla.org/docs/Web/API/CanvasPattern/setTransform)
+  - [`api.CanvasRenderingContext2D.getTransform`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/getTransform)
+  - [`api.CanvasRenderingContext2D.isPointInStroke`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isPointInStroke) +1
+  - [`api.CanvasRenderingContext2D.resetTransform`](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/resetTransform)
+  - `api.CanvasRenderingContext2D.setTransform.matrix_parameter`
+  - [`api.CredentialsContainer.store`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/store)
+  - [`api.CustomElementRegistry`](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry) +1 +1 +1 +1
+  - [`api.DOMException.DOMException`](https://developer.mozilla.org/docs/Web/API/DOMException/DOMException)
+  - [`api.DOMMatrix`](https://developer.mozilla.org/docs/Web/API/DOMMatrix) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.DOMMatrixReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.DOMPoint`](https://developer.mozilla.org/docs/Web/API/DOMPoint) +1 +1 +1 +1 +1 +1 +1
+  - [`api.DOMPointReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.DOMQuad`](https://developer.mozilla.org/docs/Web/API/DOMQuad) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) +1 +1 +1 +1 +1
   - `api.DOMRectList`
-  - [`api.DOMRectReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly)
-  - [`api.EventSource`](https://developer.mozilla.org/docs/Web/API/EventSource)
-  - [`api.FileSystemDirectoryEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry)
-  - [`api.FileSystemEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemEntry)
-  - [`api.FileSystemFileEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry)
-  - [`api.FontFace`](https://developer.mozilla.org/docs/Web/API/FontFace)
-  - [`api.FontFaceSet`](https://developer.mozilla.org/docs/Web/API/FontFaceSet)
-  - [`api.HTMLDetailsElement`](https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement)
-  - [`api.HTMLSlotElement`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement)
-  - [`api.ImageBitmapRenderingContext`](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext)
+  - [`api.DOMRectReadOnly`](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly) +1 +1 +1 +1 +1 +1
+  - [`api.Document.elementsFromPoint`](https://developer.mozilla.org/docs/Web/API/Document/elementsFromPoint)
+  - [`api.Document.fonts`](https://developer.mozilla.org/docs/Web/API/Document/fonts)
+  - [`api.Element.DOMActivate_event`](https://developer.mozilla.org/docs/Web/API/Element/DOMActivate_event)
+  - [`api.Element.assignedSlot`](https://developer.mozilla.org/docs/Web/API/Element/assignedSlot)
+  - [`api.Element.attachShadow`](https://developer.mozilla.org/docs/Web/API/Element/attachShadow)
+  - [`api.Element.hasPointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/hasPointerCapture)
+  - [`api.Element.input_event`](https://developer.mozilla.org/docs/Web/API/Element/input_event)
+  - [`api.Element.scroll`](https://developer.mozilla.org/docs/Web/API/Element/scroll) +1 +1
+  - [`api.Element.scrollBy`](https://developer.mozilla.org/docs/Web/API/Element/scrollBy) +1 +1
+  - [`api.Element.scrollIntoView`](https://developer.mozilla.org/docs/Web/API/Element/scrollIntoView)
+  - [`api.Element.scrollTo`](https://developer.mozilla.org/docs/Web/API/Element/scrollTo) +1 +1
+  - [`api.Element.shadowRoot`](https://developer.mozilla.org/docs/Web/API/Element/shadowRoot)
+  - [`api.Element.slot`](https://developer.mozilla.org/docs/Web/API/Element/slot)
+  - [`api.Event.composed`](https://developer.mozilla.org/docs/Web/API/Event/composed)
+  - [`api.Event.composedPath`](https://developer.mozilla.org/docs/Web/API/Event/composedPath)
+  - [`api.EventSource`](https://developer.mozilla.org/docs/Web/API/EventSource) +1
+  - `api.EventSource.EventSource.options_withCredentials_parameter` +1 +1 +1 +1 +1 +1 +1 +1
+  - `api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch`
+  - [`api.File.File`](https://developer.mozilla.org/docs/Web/API/File/File)
+  - [`api.FileSystemDirectoryEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryEntry) +1 +1 +1
+  - [`api.FileSystemDirectoryReader.readEntries`](https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryReader/readEntries)
+  - [`api.FileSystemEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemEntry) +1 +1 +1 +1 +1 +1
+  - [`api.FileSystemFileEntry`](https://developer.mozilla.org/docs/Web/API/FileSystemFileEntry) +1
+  - [`api.FontFace`](https://developer.mozilla.org/docs/Web/API/FontFace) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.FontFaceSet`](https://developer.mozilla.org/docs/Web/API/FontFaceSet) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - `api.Geolocation.secure_context_required`
+  - `api.GeolocationCoordinates.secure_context_required`
+  - [`api.HTMLAnchorElement.password`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/password)
+  - [`api.HTMLAnchorElement.username`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/username)
+  - [`api.HTMLAreaElement.password`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/password)
+  - [`api.HTMLAreaElement.username`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/username)
+  - [`api.HTMLCanvasElement.captureStream`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/captureStream)
+  - `api.HTMLCanvasElement.getContext.bitmaprenderer_context`
+  - `api.HTMLCanvasElement.getContext.webgl_context` +1
+  - [`api.HTMLCanvasElement.toBlob`](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/toBlob) +1
+  - [`api.HTMLDetailsElement`](https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement) +1 +1
+  - `api.HTMLEmbedElement.align`
+  - `api.HTMLEmbedElement.type`
+  - [`api.HTMLIFrameElement.srcdoc`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/srcdoc)
+  - [`api.HTMLImageElement.decode`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decode)
+  - [`api.HTMLImageElement.decoding`](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decoding)
+  - [`api.HTMLInputElement.setRangeText`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/setRangeText)
+  - [`api.HTMLInputElement.webkitEntries`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitEntries)
+  - [`api.HTMLLinkElement.sizes`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/sizes)
+  - [`api.HTMLMediaElement.waitingforkey_event`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/waitingforkey_event)
+  - [`api.HTMLOListElement.reversed`](https://developer.mozilla.org/docs/Web/API/HTMLOListElement/reversed)
+  - [`api.HTMLSelectElement.autocomplete`](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/autocomplete)
+  - [`api.HTMLSlotElement`](https://developer.mozilla.org/docs/Web/API/HTMLSlotElement) +1 +1 +1 +1
+  - [`api.HTMLTextAreaElement.autocomplete`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/autocomplete)
+  - `api.HTMLTextAreaElement.selectionDirection`
+  - `api.HTMLTextAreaElement.setRangeText`
+  - [`api.HTMLVideoElement.resize_event`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/resize_event)
+  - [`api.History.scrollRestoration`](https://developer.mozilla.org/docs/Web/API/History/scrollRestoration)
+  - [`api.IDBCursor.continuePrimaryKey`](https://developer.mozilla.org/docs/Web/API/IDBCursor/continuePrimaryKey)
+  - [`api.IDBDatabase.close_event`](https://developer.mozilla.org/docs/Web/API/IDBDatabase/close_event)
+  - [`api.IDBIndex.getAll`](https://developer.mozilla.org/docs/Web/API/IDBIndex/getAll)
+  - [`api.IDBIndex.getAllKeys`](https://developer.mozilla.org/docs/Web/API/IDBIndex/getAllKeys)
+  - [`api.IDBKeyRange.includes`](https://developer.mozilla.org/docs/Web/API/IDBKeyRange/includes)
+  - [`api.IDBObjectStore.autoIncrement`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/autoIncrement)
+  - [`api.IDBObjectStore.getAll`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getAll)
+  - [`api.IDBObjectStore.getAllKeys`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getAllKeys)
+  - [`api.IDBObjectStore.getKey`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/getKey)
+  - [`api.IDBObjectStore.openKeyCursor`](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/openKeyCursor)
+  - [`api.IDBTransaction.objectStoreNames`](https://developer.mozilla.org/docs/Web/API/IDBTransaction/objectStoreNames)
+  - [`api.IDBVersionChangeEvent.IDBVersionChangeEvent`](https://developer.mozilla.org/docs/Web/API/IDBVersionChangeEvent/IDBVersionChangeEvent)
+  - [`api.ImageBitmapRenderingContext`](https://developer.mozilla.org/docs/Web/API/ImageBitmapRenderingContext) +1
   - [`api.InputDeviceInfo`](https://developer.mozilla.org/docs/Web/API/InputDeviceInfo)
-  - [`api.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent)
-  - [`api.MediaCapabilities`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities)
-  - [`api.PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver)
-  - [`api.PerformanceObserverEntryList`](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList)
-  - [`api.PromiseRejectionEvent`](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent)
-  - [`api.RTCCertificate`](https://developer.mozilla.org/docs/Web/API/RTCCertificate)
-  - [`api.RTCDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCDataChannel)
-  - [`api.RTCDataChannelEvent`](https://developer.mozilla.org/docs/Web/API/RTCDataChannelEvent)
-  - [`api.RTCStatsReport`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport)
-  - [`api.RTCTrackEvent`](https://developer.mozilla.org/docs/Web/API/RTCTrackEvent)
+  - [`api.InputEvent`](https://developer.mozilla.org/docs/Web/API/InputEvent) +1 +1 +1 +1
+  - [`api.KeyboardEvent.code`](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/code)
+  - `api.KeyboardEvent.getModifierState.key_parameter_altgraph`
+  - `api.KeyboardEvent.getModifierState.key_parameter_meta`
+  - [`api.KeyboardEvent.isComposing`](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/isComposing)
+  - [`api.MediaCapabilities`](https://developer.mozilla.org/docs/Web/API/MediaCapabilities) +1
+  - `api.MediaDevices.getUserMedia.secure_context_required`
+  - [`api.MediaElementAudioSourceNode.mediaElement`](https://developer.mozilla.org/docs/Web/API/MediaElementAudioSourceNode/mediaElement)
+  - [`api.MediaKeySession.keystatuseschange_event`](https://developer.mozilla.org/docs/Web/API/MediaKeySession/keystatuseschange_event)
+  - [`api.MediaKeySession.message_event`](https://developer.mozilla.org/docs/Web/API/MediaKeySession/message_event)
+  - [`api.MediaStream.removetrack_event`](https://developer.mozilla.org/docs/Web/API/MediaStream/removetrack_event)
+  - [`api.MediaStreamAudioSourceNode.mediaStream`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioSourceNode/mediaStream)
+  - `api.Navigator.geolocation.secure_context_required`
+  - [`api.Navigator.mediaCapabilities`](https://developer.mozilla.org/docs/Web/API/Navigator/mediaCapabilities)
+  - `api.Navigator.mediaDevices.secure_context_required`
+  - [`api.Node.getRootNode`](https://developer.mozilla.org/docs/Web/API/Node/getRootNode)
+  - [`api.Node.isConnected`](https://developer.mozilla.org/docs/Web/API/Node/isConnected)
+  - [`api.NodeList.@@iterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+  - [`api.PageTransitionEvent.PageTransitionEvent`](https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/PageTransitionEvent)
+  - [`api.Path2D.addPath`](https://developer.mozilla.org/docs/Web/API/Path2D/addPath)
+  - [`api.Performance.resourcetimingbufferfull_event`](https://developer.mozilla.org/docs/Web/API/Performance/resourcetimingbufferfull_event)
+  - [`api.PerformanceObserver`](https://developer.mozilla.org/docs/Web/API/PerformanceObserver) +1 +1 +1 +1 +1
+  - [`api.PerformanceObserverEntryList`](https://developer.mozilla.org/docs/Web/API/PerformanceObserverEntryList) +1 +1 +1
+  - [`api.PointerEvent.tangentialPressure`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tangentialPressure)
+  - [`api.ProcessingInstruction.sheet`](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/sheet)
+  - [`api.PromiseRejectionEvent`](https://developer.mozilla.org/docs/Web/API/PromiseRejectionEvent) +1 +1 +1
+  - [`api.RTCCertificate`](https://developer.mozilla.org/docs/Web/API/RTCCertificate) +1
+  - [`api.RTCDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCDataChannel) +1
+  - `api.RTCDataChannel.binaryType.arraybuffer_value` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.RTCDataChannelEvent`](https://developer.mozilla.org/docs/Web/API/RTCDataChannelEvent) +1 +1
+  - `api.RTCPeerConnection.addIceCandidate.returns_promise`
+  - [`api.RTCPeerConnection.addTrack`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTrack)
+  - [`api.RTCPeerConnection.addTransceiver`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver) +1 +1
+  - `api.RTCPeerConnection.createAnswer.returns_promise`
+  - [`api.RTCPeerConnection.createDataChannel`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createDataChannel)
+  - `api.RTCPeerConnection.createOffer.returns_promise`
+  - [`api.RTCPeerConnection.currentLocalDescription`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/currentLocalDescription)
+  - [`api.RTCPeerConnection.currentRemoteDescription`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/currentRemoteDescription)
+  - [`api.RTCPeerConnection.datachannel_event`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/datachannel_event)
+  - [`api.RTCPeerConnection.generateCertificate_static`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/generateCertificate_static)
+  - [`api.RTCPeerConnection.getReceivers`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getReceivers)
+  - [`api.RTCPeerConnection.getSenders`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getSenders)
+  - `api.RTCPeerConnection.getStats.returns_promise`
+  - [`api.RTCPeerConnection.getTransceivers`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getTransceivers)
+  - [`api.RTCPeerConnection.pendingLocalDescription`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/pendingLocalDescription)
+  - [`api.RTCPeerConnection.pendingRemoteDescription`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/pendingRemoteDescription)
+  - [`api.RTCPeerConnection.removeTrack`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/removeTrack)
+  - `api.RTCPeerConnection.setLocalDescription.returns_promise`
+  - `api.RTCPeerConnection.setRemoteDescription.returns_promise`
+  - [`api.RTCPeerConnection.track_event`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/track_event)
+  - [`api.RTCRtpReceiver.getSynchronizationSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getSynchronizationSources) +1 +1
+  - [`api.RTCRtpSender.replaceTrack`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/replaceTrack)
+  - [`api.RTCRtpTransceiver.currentDirection`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/currentDirection)
+  - [`api.RTCRtpTransceiver.direction`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/direction)
+  - [`api.RTCRtpTransceiver.mid`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/mid)
+  - [`api.RTCRtpTransceiver.receiver`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/receiver)
+  - [`api.RTCRtpTransceiver.sender`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/sender)
+  - [`api.RTCRtpTransceiver.stopped`](https://developer.mozilla.org/docs/Web/API/RTCRtpTransceiver/stopped)
+  - [`api.RTCStatsReport`](https://developer.mozilla.org/docs/Web/API/RTCStatsReport) +1 +1 +1 +1 +1 +1 +1 +1
+  - `api.RTCStatsReport.type_candidate-pair.bytesReceived`
+  - `api.RTCStatsReport.type_candidate-pair.bytesSent`
+  - `api.RTCStatsReport.type_candidate-pair.localCandidateId`
+  - `api.RTCStatsReport.type_candidate-pair.nominated`
+  - `api.RTCStatsReport.type_candidate-pair.remoteCandidateId`
+  - `api.RTCStatsReport.type_candidate-pair.state`
+  - `api.RTCStatsReport.type_candidate-pair.transportId` +1 +1
+  - [`api.RTCTrackEvent`](https://developer.mozilla.org/docs/Web/API/RTCTrackEvent) +1 +1 +1 +1 +1
+  - [`api.ReadableStream.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream/ReadableStream)
+  - [`api.ReadableStream.tee`](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee)
   - [`api.SVGAnimateElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateElement)
   - [`api.SVGAnimateMotionElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateMotionElement)
   - [`api.SVGAnimateTransformElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimateTransformElement)
-  - [`api.SVGAnimationElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement)
-  - [`api.SVGFEDropShadowElement`](https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement)
-  - [`api.SVGGeometryElement`](https://developer.mozilla.org/docs/Web/API/SVGGeometryElement)
-  - [`api.SVGMPathElement`](https://developer.mozilla.org/docs/Web/API/SVGMPathElement)
+  - [`api.SVGAnimationElement`](https://developer.mozilla.org/docs/Web/API/SVGAnimationElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.SVGFEDropShadowElement`](https://developer.mozilla.org/docs/Web/API/SVGFEDropShadowElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.SVGGeometryElement`](https://developer.mozilla.org/docs/Web/API/SVGGeometryElement) +1 +1 +1 +1 +1
+  - [`api.SVGMPathElement`](https://developer.mozilla.org/docs/Web/API/SVGMPathElement) +1
+  - `api.SVGRadialGradientElement.fr`
+  - `api.SVGSVGElement.animationsPaused`
   - [`api.SVGSetElement`](https://developer.mozilla.org/docs/Web/API/SVGSetElement)
-  - [`api.ShadowRoot`](https://developer.mozilla.org/docs/Web/API/ShadowRoot)
-  - [`api.TextDecoder`](https://developer.mozilla.org/docs/Web/API/TextDecoder)
-  - [`api.TextEncoder`](https://developer.mozilla.org/docs/Web/API/TextEncoder)
-  - [`api.WEBGL_compressed_texture_astc`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc)
+  - [`api.Screen.availLeft`](https://developer.mozilla.org/docs/Web/API/Screen/availLeft) +1
+  - [`api.Screen.availTop`](https://developer.mozilla.org/docs/Web/API/Screen/availTop) +1
+  - [`api.Selection.modify`](https://developer.mozilla.org/docs/Web/API/Selection/modify)
+  - [`api.ServiceWorkerContainer.startMessages`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/startMessages)
+  - [`api.ShadowRoot`](https://developer.mozilla.org/docs/Web/API/ShadowRoot) +1 +1 +1 +1 +1 +1 +1
+  - [`api.SourceBuffer.changeType`](https://developer.mozilla.org/docs/Web/API/SourceBuffer/changeType)
+  - [`api.SubtleCrypto.decrypt`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/decrypt)
+  - [`api.SubtleCrypto.deriveBits`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveBits)
+  - [`api.SubtleCrypto.deriveKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey)
+  - [`api.SubtleCrypto.digest`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/digest)
+  - [`api.SubtleCrypto.encrypt`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/encrypt)
+  - [`api.SubtleCrypto.exportKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey)
+  - [`api.SubtleCrypto.generateKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)
+  - [`api.SubtleCrypto.importKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey)
+  - [`api.SubtleCrypto.sign`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign)
+  - [`api.SubtleCrypto.unwrapKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/unwrapKey)
+  - [`api.SubtleCrypto.verify`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify)
+  - `api.SubtleCrypto.worker_support`
+  - [`api.SubtleCrypto.wrapKey`](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/wrapKey)
+  - [`api.Text.assignedSlot`](https://developer.mozilla.org/docs/Web/API/Text/assignedSlot)
+  - [`api.TextDecoder`](https://developer.mozilla.org/docs/Web/API/TextDecoder) +1 +1 +1 +1 +1 +1
+  - [`api.TextEncoder`](https://developer.mozilla.org/docs/Web/API/TextEncoder) +1 +1 +1 +1
+  - [`api.TransitionEvent.pseudoElement`](https://developer.mozilla.org/docs/Web/API/TransitionEvent/pseudoElement)
+  - [`api.UIEvent.which`](https://developer.mozilla.org/docs/Web/API/UIEvent/which)
+  - [`api.VTTCue.VTTCue`](https://developer.mozilla.org/docs/Web/API/VTTCue/VTTCue)
+  - [`api.VTTCue.align`](https://developer.mozilla.org/docs/Web/API/VTTCue/align)
+  - [`api.VTTCue.line`](https://developer.mozilla.org/docs/Web/API/VTTCue/line)
+  - [`api.VTTCue.position`](https://developer.mozilla.org/docs/Web/API/VTTCue/position)
+  - [`api.VTTCue.size`](https://developer.mozilla.org/docs/Web/API/VTTCue/size)
+  - [`api.VTTCue.snapToLines`](https://developer.mozilla.org/docs/Web/API/VTTCue/snapToLines)
+  - [`api.VTTCue.vertical`](https://developer.mozilla.org/docs/Web/API/VTTCue/vertical)
+  - [`api.WEBGL_compressed_texture_astc`](https://developer.mozilla.org/docs/Web/API/WEBGL_compressed_texture_astc) +1
+  - [`api.Window.customElements`](https://developer.mozilla.org/docs/Web/API/Window/customElements)
+  - [`api.Window.find`](https://developer.mozilla.org/docs/Web/API/Window/find)
+  - [`api.Window.languagechange_event`](https://developer.mozilla.org/docs/Web/API/Window/languagechange_event)
+  - [`api.Window.rejectionhandled_event`](https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event)
+  - `api.Window.scroll.options_left_parameter`
+  - `api.Window.scroll.options_top_parameter`
+  - `api.Window.scrollBy.options_left_parameter`
+  - `api.Window.scrollBy.options_top_parameter`
+  - `api.Window.scrollTo.options_left_parameter`
+  - `api.Window.scrollTo.options_top_parameter`
+  - [`api.Window.unhandledrejection_event`](https://developer.mozilla.org/docs/Web/API/Window/unhandledrejection_event)
+  - `api.XMLHttpRequest.getAllResponseHeaders.header_names_lowercase`
+  - [`api.XMLHttpRequest.responseType.json_value`](https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/responseType#json)
+  - [`api.console.countReset_static`](https://developer.mozilla.org/docs/Web/API/console/countReset_static)
+  - [`api.console.timeLog_static`](https://developer.mozilla.org/docs/Web/API/console/timeLog_static)
+  - `api.crypto.worker_support`
+  - `api.fetch.blob_data_support`
   - [`api.queueMicrotask`](https://developer.mozilla.org/docs/Web/API/queueMicrotask)
+  - `css.at-rules.font-face.OpenType_COLRv0`
+  - [`css.at-rules.font-face.font-display`](https://developer.mozilla.org/docs/Web/CSS/@font-face/font-display)
+  - `css.at-rules.keyframes.ignore_important_declarations`
+  - [`css.at-rules.media.calc`](https://developer.mozilla.org/docs/Web/CSS/calc())
+  - [`css.at-rules.media.display-mode`](https://developer.mozilla.org/docs/Web/CSS/@media/display-mode)
+  - [`css.at-rules.media.monochrome`](https://developer.mozilla.org/docs/Web/CSS/@media/monochrome)
+  - [`css.at-rules.media.prefers-color-scheme`](https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme)
+  - [`css.at-rules.media.prefers-reduced-motion`](https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-motion)
+  - `css.properties.align-content.flex_context.space-evenly`
+  - `css.properties.align-content.flex_context.stretch`
+  - `css.properties.align-items.grid_context.start_end`
+  - `css.properties.align-self.flex_context.stretch`
   - [`css.properties.all`](https://developer.mozilla.org/docs/Web/CSS/all)
   - [`css.properties.background-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/background-blend-mode)
-  - [`css.properties.block-size`](https://developer.mozilla.org/docs/Web/CSS/block-size)
+  - [`css.properties.block-size`](https://developer.mozilla.org/docs/Web/CSS/block-size) +1 +1
   - [`css.properties.border-block-end`](https://developer.mozilla.org/docs/Web/CSS/border-block-end)
   - [`css.properties.border-block-end-color`](https://developer.mozilla.org/docs/Web/CSS/border-block-end-color)
   - [`css.properties.border-block-end-style`](https://developer.mozilla.org/docs/Web/CSS/border-block-end-style)
@@ -934,92 +2065,332 @@
   - [`css.properties.border-inline-start-color`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color)
   - [`css.properties.border-inline-start-style`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style)
   - [`css.properties.border-inline-start-width`](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width)
-  - [`css.properties.box-decoration-break`](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break)
+  - [`css.properties.box-decoration-break`](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break) +1 +1
   - [`css.properties.caret-color`](https://developer.mozilla.org/docs/Web/CSS/caret-color)
-  - [`css.properties.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path)
+  - [`css.properties.clip-path`](https://developer.mozilla.org/docs/Web/CSS/clip-path) +1 +1
+  - `css.properties.column-count.auto`
+  - `css.properties.column-span.all`
+  - `css.properties.column-span.none`
+  - `css.properties.content.element_replacement`
+  - `css.properties.cursor.url_positioning_syntax`
+  - [`css.properties.custom-property.env`](https://developer.mozilla.org/docs/Web/CSS/env()) +1 +1 +1 +1
+  - `css.properties.display.contents`
+  - `css.properties.display.flow-root`
+  - `css.properties.font.font_stretch_support`
   - [`css.properties.font-kerning`](https://developer.mozilla.org/docs/Web/CSS/font-kerning)
   - [`css.properties.font-smooth`](https://developer.mozilla.org/docs/Web/CSS/font-smooth)
-  - [`css.properties.font-variant-caps`](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps)
-  - [`css.properties.font-variant-east-asian`](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian)
-  - [`css.properties.font-variant-ligatures`](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures)
-  - [`css.properties.font-variant-numeric`](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric)
-  - [`css.properties.image-rendering`](https://developer.mozilla.org/docs/Web/CSS/image-rendering)
-  - [`css.properties.inline-size`](https://developer.mozilla.org/docs/Web/CSS/inline-size)
+  - `css.properties.font-style.oblique-angle`
+  - `css.properties.font-variant.css_fonts_shorthand`
+  - [`css.properties.font-variant-caps`](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps) +1 +1 +1 +1 +1 +1 +1
+  - [`css.properties.font-variant-east-asian`](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.properties.font-variant-ligatures`](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`css.properties.font-variant-numeric`](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - `css.properties.grid-template.none`
+  - `css.properties.grid-template-areas.none`
+  - `css.properties.grid-template-columns.auto`
+  - `css.properties.grid-template-columns.max-content`
+  - `css.properties.grid-template-columns.min-content`
+  - `css.properties.grid-template-columns.none`
+  - `css.properties.grid-template-rows.auto`
+  - `css.properties.grid-template-rows.max-content`
+  - `css.properties.grid-template-rows.min-content`
+  - `css.properties.grid-template-rows.none`
+  - `css.properties.height.max-content`
+  - `css.properties.height.min-content`
+  - [`css.properties.image-rendering`](https://developer.mozilla.org/docs/Web/CSS/image-rendering) +1 +1
+  - [`css.properties.inline-size`](https://developer.mozilla.org/docs/Web/CSS/inline-size) +1 +1
   - [`css.properties.isolation`](https://developer.mozilla.org/docs/Web/CSS/isolation)
+  - `css.properties.justify-content.flex_context.space-evenly`
+  - `css.properties.justify-content.flex_context.stretch`
+  - `css.properties.letter-spacing.svg_elements`
+  - `css.properties.list-style-type.arabic-indic`
+  - `css.properties.list-style-type.bengali`
+  - `css.properties.list-style-type.cambodian`
+  - `css.properties.list-style-type.cjk-earthly-branch`
+  - `css.properties.list-style-type.cjk-heavenly-stem`
+  - `css.properties.list-style-type.cjk-ideographic`
+  - `css.properties.list-style-type.devanagari`
+  - `css.properties.list-style-type.ethiopic-halehame-ti-er`
+  - `css.properties.list-style-type.ethiopic-halehame-ti-et`
+  - `css.properties.list-style-type.gujarati`
+  - `css.properties.list-style-type.gurmukhi`
+  - `css.properties.list-style-type.hangul`
+  - `css.properties.list-style-type.hangul-consonant`
+  - `css.properties.list-style-type.kannada`
+  - `css.properties.list-style-type.khmer`
+  - `css.properties.list-style-type.lao`
+  - `css.properties.list-style-type.lower-armenian`
+  - `css.properties.list-style-type.malayalam`
+  - `css.properties.list-style-type.mongolian`
+  - `css.properties.list-style-type.myanmar`
+  - `css.properties.list-style-type.oriya`
+  - `css.properties.list-style-type.persian`
+  - `css.properties.list-style-type.telugu`
+  - `css.properties.list-style-type.thai`
+  - `css.properties.list-style-type.tibetan`
+  - `css.properties.list-style-type.upper-armenian`
+  - `css.properties.list-style-type.urdu`
   - [`css.properties.margin-block-end`](https://developer.mozilla.org/docs/Web/CSS/margin-block-end)
   - [`css.properties.margin-block-start`](https://developer.mozilla.org/docs/Web/CSS/margin-block-start)
   - [`css.properties.margin-inline-end`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-end)
   - [`css.properties.margin-inline-start`](https://developer.mozilla.org/docs/Web/CSS/margin-inline-start)
-  - [`css.properties.mask`](https://developer.mozilla.org/docs/Web/CSS/mask)
-  - [`css.properties.mask-type`](https://developer.mozilla.org/docs/Web/CSS/mask-type)
-  - [`css.properties.max-block-size`](https://developer.mozilla.org/docs/Web/CSS/max-block-size)
-  - [`css.properties.max-inline-size`](https://developer.mozilla.org/docs/Web/CSS/max-inline-size)
-  - [`css.properties.min-block-size`](https://developer.mozilla.org/docs/Web/CSS/min-block-size)
-  - [`css.properties.min-inline-size`](https://developer.mozilla.org/docs/Web/CSS/min-inline-size)
+  - [`css.properties.mask-type`](https://developer.mozilla.org/docs/Web/CSS/mask-type) +1 +1
+  - [`css.properties.max-block-size`](https://developer.mozilla.org/docs/Web/CSS/max-block-size) +1 +1
+  - `css.properties.max-height.max-content`
+  - `css.properties.max-height.min-content`
+  - `css.properties.max-height.none`
+  - [`css.properties.max-inline-size`](https://developer.mozilla.org/docs/Web/CSS/max-inline-size) +1 +1
+  - `css.properties.max-width.max-content`
+  - `css.properties.max-width.min-content`
+  - [`css.properties.min-block-size`](https://developer.mozilla.org/docs/Web/CSS/min-block-size) +1 +1
+  - `css.properties.min-height.max-content`
+  - `css.properties.min-height.min-content`
+  - [`css.properties.min-inline-size`](https://developer.mozilla.org/docs/Web/CSS/min-inline-size) +1 +1
+  - `css.properties.min-width.max-content`
+  - `css.properties.min-width.min-content`
   - [`css.properties.mix-blend-mode`](https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode)
-  - [`css.properties.object-fit`](https://developer.mozilla.org/docs/Web/CSS/object-fit)
+  - [`css.properties.object-fit`](https://developer.mozilla.org/docs/Web/CSS/object-fit) +1 +1 +1 +1 +1
   - [`css.properties.object-position`](https://developer.mozilla.org/docs/Web/CSS/object-position)
+  - `css.properties.overflow.auto`
+  - `css.properties.overflow-x.auto`
+  - `css.properties.overflow-y.auto`
   - [`css.properties.padding-block-end`](https://developer.mozilla.org/docs/Web/CSS/padding-block-end)
   - [`css.properties.padding-block-start`](https://developer.mozilla.org/docs/Web/CSS/padding-block-start)
   - [`css.properties.padding-inline-end`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-end)
   - [`css.properties.padding-inline-start`](https://developer.mozilla.org/docs/Web/CSS/padding-inline-start)
-  - [`css.properties.place-content`](https://developer.mozilla.org/docs/Web/CSS/place-content)
-  - [`css.properties.place-items`](https://developer.mozilla.org/docs/Web/CSS/place-items)
-  - [`css.properties.place-self`](https://developer.mozilla.org/docs/Web/CSS/place-self)
-  - [`css.properties.resize`](https://developer.mozilla.org/docs/Web/CSS/resize)
-  - [`css.properties.scroll-snap-align`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align)
+  - [`css.properties.place-content`](https://developer.mozilla.org/docs/Web/CSS/place-content) +1 +1
+  - [`css.properties.place-items`](https://developer.mozilla.org/docs/Web/CSS/place-items) +1 +1
+  - [`css.properties.place-self`](https://developer.mozilla.org/docs/Web/CSS/place-self) +1 +1
+  - [`css.properties.resize`](https://developer.mozilla.org/docs/Web/CSS/resize) +1
+  - `css.properties.scroll-padding.auto`
+  - [`css.properties.scroll-snap-align`](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align) +1 +1 +1 +1
   - [`css.properties.shape-image-threshold`](https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold)
   - [`css.properties.shape-margin`](https://developer.mozilla.org/docs/Web/CSS/shape-margin)
-  - [`css.properties.shape-outside`](https://developer.mozilla.org/docs/Web/CSS/shape-outside)
+  - [`css.properties.shape-outside`](https://developer.mozilla.org/docs/Web/CSS/shape-outside) +1 +1 +1 +1 +1 +1
+  - `css.properties.text-align.end`
+  - `css.properties.text-align.start`
+  - `css.properties.text-decoration.includes_color-and-style`
   - [`css.properties.text-decoration-color`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-color)
-  - [`css.properties.text-decoration-line`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line)
-  - [`css.properties.text-decoration-style`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style)
-  - [`css.properties.text-rendering`](https://developer.mozilla.org/docs/Web/CSS/text-rendering)
+  - [`css.properties.text-decoration-line`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line) +1
+  - [`css.properties.text-decoration-style`](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style) +1
+  - `css.properties.text-emphasis-position.left`
+  - `css.properties.text-emphasis-position.right`
+  - `css.properties.text-orientation.sideways`
+  - [`css.properties.text-rendering`](https://developer.mozilla.org/docs/Web/CSS/text-rendering) +1 +1
   - [`css.properties.transform-box`](https://developer.mozilla.org/docs/Web/CSS/transform-box)
+  - `css.properties.unicode-bidi.isolate`
+  - `css.properties.unicode-bidi.isolate-override`
+  - `css.properties.unicode-bidi.plaintext`
   - [`css.properties.user-select`](https://developer.mozilla.org/docs/Web/CSS/user-select)
-  - [`css.properties.will-change`](https://developer.mozilla.org/docs/Web/CSS/will-change)
+  - `css.properties.width.max-content`
+  - `css.properties.width.min-content`
+  - `css.properties.width.stretch`
+  - [`css.properties.will-change`](https://developer.mozilla.org/docs/Web/CSS/will-change) +1 +1 +1
+  - `css.properties.word-spacing.svg_elements`
+  - `css.properties.writing-mode.horizontal-tb`
+  - `css.properties.writing-mode.vertical-lr`
+  - `css.properties.writing-mode.vertical-rl`
   - [`css.selectors.any-link`](https://developer.mozilla.org/docs/Web/CSS/:any-link)
+  - `css.selectors.attribute.case_insensitive_modifier`
   - [`css.selectors.cue`](https://developer.mozilla.org/docs/Web/CSS/::cue)
   - [`css.selectors.default`](https://developer.mozilla.org/docs/Web/CSS/:default)
   - [`css.selectors.defined`](https://developer.mozilla.org/docs/Web/CSS/:defined)
   - [`css.selectors.focus-within`](https://developer.mozilla.org/docs/Web/CSS/:focus-within)
   - [`css.selectors.host`](https://developer.mozilla.org/docs/Web/CSS/:host)
   - [`css.selectors.hostfunction`](https://developer.mozilla.org/docs/Web/CSS/:host())
+  - `css.selectors.indeterminate.radio`
+  - `css.selectors.invalid.form`
   - [`css.selectors.placeholder`](https://developer.mozilla.org/docs/Web/CSS/::placeholder)
-  - [`css.selectors.placeholder-shown`](https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown)
-  - [`css.selectors.scope`](https://developer.mozilla.org/docs/Web/CSS/:scope)
+  - [`css.selectors.placeholder-shown`](https://developer.mozilla.org/docs/Web/CSS/:placeholder-shown) +1
+  - [`css.selectors.scope`](https://developer.mozilla.org/docs/Web/CSS/:scope) +1
   - [`css.selectors.slotted`](https://developer.mozilla.org/docs/Web/CSS/::slotted)
-  - [`css.types.basic-shape`](https://developer.mozilla.org/docs/Web/CSS/basic-shape)
+  - `css.selectors.valid.form`
+  - [`css.types.basic-shape`](https://developer.mozilla.org/docs/Web/CSS/basic-shape) +1 +1 +1 +1 +1
   - [`css.types.blend-mode`](https://developer.mozilla.org/docs/Web/CSS/blend-mode)
+  - `css.types.color.hsl.alpha_parameter`
+  - `css.types.color.hsl.space_separated_parameters`
+  - `css.types.color.rgb.alpha_parameter`
+  - `css.types.color.rgb.float_values`
+  - `css.types.color.rgb.space_separated_parameters`
+  - `css.types.color.rgb_hexadecimal_notation.alpha_hexadecimal_notation`
+  - `css.types.image.gradient.linear-gradient.doubleposition`
+  - `css.types.image.gradient.linear-gradient.interpolation_hints`
+  - `css.types.image.gradient.radial-gradient.doubleposition`
+  - `css.types.image.gradient.radial-gradient.interpolation_hints`
+  - `css.types.image.gradient.repeating-linear-gradient.doubleposition`
+  - `css.types.image.gradient.repeating-linear-gradient.interpolation_hints`
+  - `css.types.image.gradient.repeating-radial-gradient.doubleposition`
+  - `css.types.image.gradient.repeating-radial-gradient.interpolation_hints`
+  - [`html.elements.a.rel.noopener`](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noopener)
+  - [`html.elements.area.rel.noopener`](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/noopener)
   - [`html.elements.bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi)
-  - [`html.elements.details`](https://developer.mozilla.org/docs/Web/HTML/Element/details)
-  - [`html.elements.image`](https://developer.mozilla.org/docs/Web/HTML/Element/image)
+  - [`html.elements.details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) +1
+  - `html.elements.iframe.sandbox.allow-modals`
+  - `html.elements.iframe.sandbox.allow-popups-to-escape-sandbox`
+  - `html.elements.img.usemap.caseless_usemap`
+  - [`html.elements.link.rel.preconnect`](https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/preconnect)
+  - `html.elements.meta.name.referrer`
   - [`html.elements.rb`](https://developer.mozilla.org/docs/Web/HTML/Element/rb)
   - [`html.elements.rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp)
   - [`html.elements.rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt)
-  - [`html.elements.slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot)
+  - `html.elements.script.type.module`
+  - [`html.elements.slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) +1
   - [`html.elements.summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary)
+  - `html.elements.textarea.autocomplete`
   - [`html.elements.wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr)
-  - [`html.global_attributes.autofocus`](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autofocus)
-  - [`http.headers.Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy)
-  - [`javascript.builtins.AsyncGenerator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator)
-  - [`javascript.builtins.AsyncGeneratorFunction`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction)
-  - [`javascript.builtins.AsyncIterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+  - `http.data-url.html_files`
+  - `http.headers.Access-Control-Expose-Headers.wildcard`
+  - [`http.headers.Content-Security-Policy.base-uri`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri)
+  - [`http.headers.Referrer-Policy`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Referrer-Policy) +1 +1 +1
+  - `http.headers.Set-Cookie.cookie_prefixes`
+  - [`javascript.builtins.Array.@@species`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species)
+  - [`javascript.builtins.Array.flat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
+  - [`javascript.builtins.Array.flatMap`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap)
+  - `javascript.builtins.Array.sort.stable_sorting`
+  - `javascript.builtins.Array.toLocaleString.locales_parameter`
+  - `javascript.builtins.Array.toLocaleString.options_parameter`
+  - [`javascript.builtins.AsyncGenerator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) +1 +1 +1
+  - [`javascript.builtins.AsyncGeneratorFunction`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction) +1
+  - [`javascript.builtins.AsyncIterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) +1
+  - `javascript.builtins.Date.UTC.optional_monthIndex`
+  - `javascript.builtins.Function.name.inferred_names`
+  - [`javascript.builtins.JSON.json_superset`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON#JavaScript_and_JSON_differences)
+  - `javascript.builtins.JSON.stringify.well_formed_stringify`
+  - [`javascript.builtins.Object.fromEntries`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries)
+  - [`javascript.builtins.Promise.@@species`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species)
+  - [`javascript.builtins.Promise.allSettled`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
+  - [`javascript.builtins.Proxy.handler.getPrototypeOf`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf)
+  - [`javascript.builtins.RegExp.@@matchAll`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll)
+  - [`javascript.builtins.RegExp.@@replace`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)
+  - [`javascript.builtins.RegExp.@@split`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split)
+  - [`javascript.builtins.RegExp.flags`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags)
+  - [`javascript.builtins.String.matchAll`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll)
+  - [`javascript.builtins.String.trimEnd`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd)
+  - [`javascript.builtins.String.trimStart`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart)
+  - [`javascript.builtins.Symbol.asyncIterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
+  - [`javascript.builtins.Symbol.description`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description)
+  - [`javascript.builtins.Symbol.match`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match)
+  - [`javascript.builtins.Symbol.matchAll`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll)
+  - [`javascript.builtins.Symbol.replace`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)
+  - [`javascript.builtins.Symbol.search`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search)
+  - [`javascript.builtins.Symbol.split`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split)
   - [`javascript.builtins.globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis)
+  - `javascript.functions.method_definitions.async_generator_methods`
+  - `javascript.functions.rest_parameters.destructuring`
   - [`javascript.grammar.numeric_separators`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators)
+  - `javascript.grammar.template_literals.template_literal_revision`
   - [`javascript.operators.async_generator_function`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/async_function*)
+  - `javascript.operators.destructuring.rest_in_objects`
+  - `javascript.operators.generator_function.trailing_comma`
   - [`javascript.operators.import`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Import)
   - [`javascript.operators.import_meta`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta)
+  - `javascript.operators.object_initializer.spread_properties`
+  - [`javascript.operators.spread.spread_in_object_literals`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals)
   - [`javascript.statements.async_generator_function`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function*)
   - [`javascript.statements.for_await_of`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of)
-  - [`svg.attributes.presentation.vector-effect`](https://developer.mozilla.org/docs/Web/SVG/Attribute/vector-effect)
-  - [`svg.elements.feDropShadow`](https://developer.mozilla.org/docs/Web/SVG/Element/feDropShadow)
+  - `javascript.statements.try_catch.optional_catch_binding`
+  - `svg.elements.a.xlink_actuate`
+  - `svg.elements.a.xlink_show`
+  - `svg.elements.a.xlink_title`
+  - `svg.elements.animate.attributeName`
+  - `svg.elements.animate.attributeType`
+  - [`svg.elements.animate.dur`](https://developer.mozilla.org/docs/Web/SVG/Attribute/dur)
+  - [`svg.elements.animate.from`](https://developer.mozilla.org/docs/Web/SVG/Attribute/from)
+  - [`svg.elements.animate.repeatCount`](https://developer.mozilla.org/docs/Web/SVG/Attribute/repeatCount)
+  - `svg.elements.animate.to`
+  - `svg.elements.animateMotion.calcMode`
+  - [`svg.elements.animateMotion.keyPoints`](https://developer.mozilla.org/docs/Web/SVG/Attribute/keyPoints)
+  - `svg.elements.animateMotion.origin`
+  - `svg.elements.animateMotion.path`
+  - `svg.elements.animateMotion.rotate`
+  - [`svg.elements.animateTransform.by`](https://developer.mozilla.org/docs/Web/SVG/Attribute/by)
+  - `svg.elements.animateTransform.from`
+  - `svg.elements.animateTransform.to`
+  - `svg.elements.animateTransform.type`
+  - [`svg.elements.feConvolveMatrix.bias`](https://developer.mozilla.org/docs/Web/SVG/Attribute/bias)
+  - [`svg.elements.feConvolveMatrix.divisor`](https://developer.mozilla.org/docs/Web/SVG/Attribute/divisor)
+  - [`svg.elements.feConvolveMatrix.edgeMode`](https://developer.mozilla.org/docs/Web/SVG/Attribute/edgeMode)
+  - [`svg.elements.feConvolveMatrix.kernelUnitLength`](https://developer.mozilla.org/docs/Web/SVG/Attribute/kernelUnitLength)
+  - [`svg.elements.feConvolveMatrix.order`](https://developer.mozilla.org/docs/Web/SVG/Attribute/order)
+  - [`svg.elements.feConvolveMatrix.preserveAlpha`](https://developer.mozilla.org/docs/Web/SVG/Attribute/preserveAlpha)
+  - [`svg.elements.feConvolveMatrix.targetX`](https://developer.mozilla.org/docs/Web/SVG/Attribute/targetX)
+  - [`svg.elements.feConvolveMatrix.targetY`](https://developer.mozilla.org/docs/Web/SVG/Attribute/targetY)
+  - [`svg.elements.feDiffuseLighting.diffuseConstant`](https://developer.mozilla.org/docs/Web/SVG/Attribute/diffuseConstant)
+  - [`svg.elements.feDiffuseLighting.kernelUnitLength`](https://developer.mozilla.org/docs/Web/SVG/Attribute/kernelUnitLength)
+  - [`svg.elements.feDiffuseLighting.surfaceScale`](https://developer.mozilla.org/docs/Web/SVG/Attribute/surfaceScale)
+  - [`svg.elements.feDisplacementMap.xChannelSelector`](https://developer.mozilla.org/docs/Web/SVG/Attribute/xChannelSelector)
+  - [`svg.elements.feDisplacementMap.yChannelSelector`](https://developer.mozilla.org/docs/Web/SVG/Attribute/yChannelSelector)
+  - [`svg.elements.feDistantLight.azimuth`](https://developer.mozilla.org/docs/Web/SVG/Attribute/azimuth)
+  - [`svg.elements.feDistantLight.elevation`](https://developer.mozilla.org/docs/Web/SVG/Attribute/elevation)
+  - [`svg.elements.feDropShadow`](https://developer.mozilla.org/docs/Web/SVG/Element/feDropShadow) +1 +1 +1 +1
+  - `svg.elements.feFlood.flood-opacity`
+  - `svg.elements.feImage.preserveAspectRatio`
+  - `svg.elements.feSpecularLighting.surfaceScale`
+  - [`svg.elements.feTurbulence.numOctaves`](https://developer.mozilla.org/docs/Web/SVG/Attribute/numOctaves)
+  - [`svg.elements.feTurbulence.stitchTiles`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stitchTiles)
+  - [`svg.elements.feTurbulence.type`](https://developer.mozilla.org/docs/Web/SVG/Attribute/type)
+  - [`svg.elements.filter.filterUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/filterUnits)
+  - [`svg.elements.filter.height`](https://developer.mozilla.org/docs/Web/SVG/Attribute/height)
+  - [`svg.elements.filter.primitiveUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/primitiveUnits)
+  - [`svg.elements.filter.width`](https://developer.mozilla.org/docs/Web/SVG/Attribute/width)
+  - [`svg.elements.filter.x`](https://developer.mozilla.org/docs/Web/SVG/Attribute/x)
+  - [`svg.elements.filter.xlink_href`](https://developer.mozilla.org/docs/Web/SVG/Attribute/xlink:href)
+  - [`svg.elements.filter.y`](https://developer.mozilla.org/docs/Web/SVG/Attribute/y)
+  - `svg.elements.image.height`
+  - `svg.elements.image.preserveAspectRatio`
+  - `svg.elements.image.width`
+  - `svg.elements.image.x`
+  - `svg.elements.image.xlink_href`
+  - `svg.elements.image.y`
+  - [`svg.elements.linearGradient.gradientTransform`](https://developer.mozilla.org/docs/Web/SVG/Attribute/gradientTransform)
+  - `svg.elements.linearGradient.gradientUnits`
+  - [`svg.elements.linearGradient.spreadMethod`](https://developer.mozilla.org/docs/Web/SVG/Attribute/spreadMethod)
+  - `svg.elements.linearGradient.x1`
+  - `svg.elements.linearGradient.x2`
+  - `svg.elements.linearGradient.xlink_href`
+  - `svg.elements.linearGradient.y1`
+  - `svg.elements.linearGradient.y2`
+  - [`svg.elements.mask.maskContentUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/maskContentUnits)
+  - [`svg.elements.mask.maskUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/maskUnits)
+  - `svg.elements.mpath.xlink_href`
+  - `svg.elements.pattern.href`
+  - [`svg.elements.pattern.patternContentUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/patternContentUnits)
+  - [`svg.elements.pattern.patternTransform`](https://developer.mozilla.org/docs/Web/SVG/Attribute/patternTransform)
+  - [`svg.elements.pattern.patternUnits`](https://developer.mozilla.org/docs/Web/SVG/Attribute/patternUnits)
+  - `svg.elements.radialGradient.cx`
+  - `svg.elements.radialGradient.cy`
+  - [`svg.elements.radialGradient.fr`](https://developer.mozilla.org/docs/Web/SVG/Attribute/fr)
+  - [`svg.elements.radialGradient.fx`](https://developer.mozilla.org/docs/Web/SVG/Attribute/fx)
+  - [`svg.elements.radialGradient.fy`](https://developer.mozilla.org/docs/Web/SVG/Attribute/fy)
+  - `svg.elements.radialGradient.gradientTransform`
+  - `svg.elements.radialGradient.gradientUnits`
+  - `svg.elements.radialGradient.href`
+  - `svg.elements.radialGradient.r`
+  - [`svg.elements.radialGradient.spreadMethod`](https://developer.mozilla.org/docs/Web/SVG/Attribute/spreadMethod)
+  - `svg.elements.radialGradient.xlink_href`
+  - `svg.elements.script.type`
+  - `svg.elements.script.xlink_href`
+  - [`svg.elements.style.media`](https://developer.mozilla.org/docs/Web/SVG/Attribute/media)
+  - `svg.elements.style.title`
+  - `svg.elements.style.type`
+  - `svg.elements.symbol.preserveAspectRatio`
+  - `svg.elements.symbol.viewBox`
+  - [`svg.elements.textPath.spacing`](https://developer.mozilla.org/docs/Web/SVG/Attribute/spacing)
+  - `svg.elements.title.tooltip_display`
+  - `svg.elements.tspan.lengthAdjust`
+  - `svg.elements.view.preserveAspectRatio`
+  - `svg.elements.view.viewBox`
+  - `svg.elements.view.zoomAndPan`
+  - [`svg.global_attributes.vector-effect`](https://developer.mozilla.org/docs/Web/SVG/Attribute/vector-effect)
 
 ## Jan 2020
 ### Browsers released:
   - {'browser':'edge','version':'79'}
   - {'browser':'firefox','version':'72'}
 ### These Features became stable across all major browsers:
+  - [`api.Element.animationend_event`](https://developer.mozilla.org/docs/Web/API/Element/animationend_event)
+  - [`api.Element.animationiteration_event`](https://developer.mozilla.org/docs/Web/API/Element/animationiteration_event)
+  - [`api.Element.animationstart_event`](https://developer.mozilla.org/docs/Web/API/Element/animationstart_event)
   - [`css.properties.column-span`](https://developer.mozilla.org/docs/Web/CSS/column-span)
   - [`css.properties.font-optical-sizing`](https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing)
 
@@ -1045,19 +2416,46 @@
   - {'browser':'chrome','version':'78'}
   - {'browser':'firefox','version':'70'}
 ### These Features became stable across all major browsers:
-  - [`api.AuthenticatorAssertionResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse)
-  - [`api.AuthenticatorAttestationResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse)
-  - [`api.AuthenticatorResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse)
-  - [`api.Credential`](https://developer.mozilla.org/docs/Web/API/Credential)
-  - [`api.CredentialsContainer`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer)
-  - [`api.MediaSource`](https://developer.mozilla.org/docs/Web/API/MediaSource)
-  - [`api.PointerEvent`](https://developer.mozilla.org/docs/Web/API/PointerEvent)
-  - [`api.PublicKeyCredential`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential)
-  - [`api.SourceBuffer`](https://developer.mozilla.org/docs/Web/API/SourceBuffer)
-  - [`api.SourceBufferList`](https://developer.mozilla.org/docs/Web/API/SourceBufferList)
-  - [`api.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange)
+  - [`api.AuthenticatorAssertionResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAssertionResponse) +1 +1 +1
+  - [`api.AuthenticatorAttestationResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse) +1
+  - [`api.AuthenticatorResponse`](https://developer.mozilla.org/docs/Web/API/AuthenticatorResponse) +1
+  - [`api.Credential`](https://developer.mozilla.org/docs/Web/API/Credential) +1 +1
+  - [`api.CredentialsContainer`](https://developer.mozilla.org/docs/Web/API/CredentialsContainer) +1
+  - `api.CredentialsContainer.create.publicKey_option` +1
+  - [`api.CredentialsContainer.create.publicKey_option.extensions.appidExclude`](https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appidexclude) +1
+  - `api.CredentialsContainer.get.publicKey_option` +1
+  - `api.CredentialsContainer.get.publicKey_option.extensions.appid`
+  - [`api.Element.gotpointercapture_event`](https://developer.mozilla.org/docs/Web/API/Element/gotpointercapture_event)
+  - [`api.Element.lostpointercapture_event`](https://developer.mozilla.org/docs/Web/API/HTMLElement/lostpointercapture_event)
+  - [`api.Element.pointercancel_event`](https://developer.mozilla.org/docs/Web/API/Element/pointercancel_event)
+  - [`api.Element.pointerdown_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerdown_event)
+  - [`api.Element.pointerenter_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerenter_event)
+  - [`api.Element.pointerleave_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerleave_event)
+  - [`api.Element.pointermove_event`](https://developer.mozilla.org/docs/Web/API/Element/pointermove_event)
+  - [`api.Element.pointerout_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerout_event)
+  - [`api.Element.pointerover_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerover_event)
+  - [`api.Element.pointerup_event`](https://developer.mozilla.org/docs/Web/API/Element/pointerup_event)
+  - [`api.Element.releasePointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/releasePointerCapture)
+  - [`api.Element.setPointerCapture`](https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture)
+  - [`api.HTMLObjectElement.contentWindow`](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/contentWindow)
+  - [`api.MediaSource`](https://developer.mozilla.org/docs/Web/API/MediaSource) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.Navigator.credentials`](https://developer.mozilla.org/docs/Web/API/Navigator/credentials)
+  - [`api.Navigator.maxTouchPoints`](https://developer.mozilla.org/docs/Web/API/Navigator/maxTouchPoints)
+  - [`api.PointerEvent`](https://developer.mozilla.org/docs/Web/API/PointerEvent) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.PublicKeyCredential`](https://developer.mozilla.org/docs/Web/API/PublicKeyCredential) +1 +1 +1 +1
+  - [`api.SourceBuffer`](https://developer.mozilla.org/docs/Web/API/SourceBuffer) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.SourceBufferList`](https://developer.mozilla.org/docs/Web/API/SourceBufferList) +1 +1 +1
+  - [`api.StaticRange`](https://developer.mozilla.org/docs/Web/API/StaticRange) +1 +1 +1 +1 +1
+  - [`api.Window.afterprint_event`](https://developer.mozilla.org/docs/Web/API/Window/afterprint_event)
+  - [`api.Window.beforeprint_event`](https://developer.mozilla.org/docs/Web/API/Window/beforeprint_event)
   - [`css.properties.line-break`](https://developer.mozilla.org/docs/Web/CSS/line-break)
-  - [`css.properties.touch-action`](https://developer.mozilla.org/docs/Web/CSS/touch-action)
+  - `css.properties.position.sticky`
+  - [`css.properties.touch-action`](https://developer.mozilla.org/docs/Web/CSS/touch-action) +1 +1 +1 +1
+  - `html.elements.a.download`
+  - [`http.headers.Set-Cookie.SameSite`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) +1
+  - `javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_hourCycle_parameter`
+  - [`javascript.builtins.Intl.NumberFormat.formatToParts`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts)
+  - [`javascript.builtins.Intl.PluralRules`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) +1 +1 +1 +1
 
 ## Sep 2019
 ### Browsers released:
@@ -1068,6 +2466,10 @@
 
 ## Aug 2019
 ### These Features became stable across all major browsers:
+  - [`api.CSSStyleSheet.addRule`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/addRule)
+  - [`api.CSSStyleSheet.removeRule`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/removeRule)
+  - [`api.CSSStyleSheet.rules`](https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/rules)
+  - [`api.HTMLTrackElement.cuechange_event`](https://developer.mozilla.org/docs/Web/API/HTMLTrackElement/cuechange_event)
   - [`css.properties.-webkit-line-clamp`](https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp)
 
 ## Jul 2019
@@ -1078,6 +2480,8 @@
 ## Jun 2019
 ### Browsers released:
   - {'browser':'chrome','version':'75'}
+### These Features became stable across all major browsers:
+  - `css.properties.word-break.break-word`
 
 ## May 2019
 ### Browsers released:
@@ -1087,18 +2491,44 @@
 ### Browsers released:
   - {'browser':'chrome','version':'74'}
 ### These Features became stable across all major browsers:
-  - [`api.AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController)
-  - [`api.HTMLDataListElement`](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement)
-  - [`api.IntersectionObserver`](https://developer.mozilla.org/docs/Web/API/IntersectionObserver)
-  - [`api.IntersectionObserverEntry`](https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry)
-  - [`api.MediaEncryptedEvent`](https://developer.mozilla.org/docs/Web/API/MediaEncryptedEvent)
-  - [`api.MediaKeyMessageEvent`](https://developer.mozilla.org/docs/Web/API/MediaKeyMessageEvent)
-  - [`api.MediaKeySession`](https://developer.mozilla.org/docs/Web/API/MediaKeySession)
-  - [`api.MediaKeyStatusMap`](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap)
-  - [`api.MediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/MediaKeySystemAccess)
-  - [`api.MediaKeys`](https://developer.mozilla.org/docs/Web/API/MediaKeys)
+  - [`api.AbortController`](https://developer.mozilla.org/docs/Web/API/AbortController) +1 +1 +1
+  - [`api.DedicatedWorkerGlobalScope.name`](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/name)
+  - [`api.Event.returnValue`](https://developer.mozilla.org/docs/Web/API/Event/returnValue)
+  - [`api.HTMLDataListElement`](https://developer.mozilla.org/docs/Web/API/HTMLDataListElement) +1
+  - [`api.HTMLInputElement.list`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/list)
+  - [`api.HTMLMediaElement.encrypted_event`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/encrypted_event)
+  - [`api.HTMLMediaElement.mediaKeys`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaKeys)
+  - [`api.HTMLMediaElement.setMediaKeys`](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys)
+  - [`api.IntersectionObserver`](https://developer.mozilla.org/docs/Web/API/IntersectionObserver) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.IntersectionObserverEntry`](https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry) +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaEncryptedEvent`](https://developer.mozilla.org/docs/Web/API/MediaEncryptedEvent) +1 +1 +1
+  - [`api.MediaKeyMessageEvent`](https://developer.mozilla.org/docs/Web/API/MediaKeyMessageEvent) +1 +1 +1
+  - [`api.MediaKeySession`](https://developer.mozilla.org/docs/Web/API/MediaKeySession) +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaKeyStatusMap`](https://developer.mozilla.org/docs/Web/API/MediaKeyStatusMap) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.MediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/MediaKeySystemAccess) +1 +1 +1
+  - [`api.MediaKeys`](https://developer.mozilla.org/docs/Web/API/MediaKeys) +1 +1
+  - [`api.MouseEvent.getModifierState`](https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState)
+  - [`api.Navigator.requestMediaKeySystemAccess`](https://developer.mozilla.org/docs/Web/API/Navigator/requestMediaKeySystemAccess)
+  - [`api.RTCRtpReceiver.getContributingSources`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getContributingSources) +1
+  - [`api.RTCRtpReceiver.getStats`](https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/getStats)
+  - [`api.RTCRtpSender.getStats`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getStats)
+  - `api.Request.credentials.default_same-origin`
+  - [`api.Request.signal`](https://developer.mozilla.org/docs/Web/API/Request/signal)
+  - [`api.VideoPlaybackQuality`](https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality) +1 +1 +1
+  - [`api.Window.event`](https://developer.mozilla.org/docs/Web/API/Window/event)
+  - `api.Worker.Worker.options_name_parameter`
+  - `css.properties.gap.grid_context.calc_values`
   - [`html.elements.datalist`](https://developer.mozilla.org/docs/Web/HTML/Element/datalist)
-  - [`svg.attributes.href`](https://developer.mozilla.org/docs/Web/SVG/Attribute/href)
+  - [`html.elements.input.list`](https://developer.mozilla.org/docs/Web/HTML/Element/input#list)
+  - [`html.elements.input.type_color`](https://developer.mozilla.org/docs/Web/HTML/Element/input/color)
+  - `http.headers.Set-Cookie.SameSite.Lax`
+  - `http.headers.Set-Cookie.SameSite.Strict`
+  - `javascript.builtins.RegExp.source.escaping`
+  - `javascript.builtins.RegExp.toString.escaping`
+  - `svg.elements.a.href`
+  - `svg.elements.textPath.href`
+  - `svg.elements.use.href`
+  - [`svg.global_attributes.href`](https://developer.mozilla.org/docs/Web/SVG/Attribute/href)
 
 ## Mar 2019
 ### Browsers released:
@@ -1109,19 +2539,31 @@
 
 ## Feb 2019
 ### These Features became stable across all major browsers:
-  - [`api.ByteLengthQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy)
-  - [`api.CountQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy)
-  - [`api.HTMLMarqueeElement`](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement)
-  - [`api.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream)
-  - [`css.properties.break-after`](https://developer.mozilla.org/docs/Web/CSS/break-after)
-  - [`css.properties.break-before`](https://developer.mozilla.org/docs/Web/CSS/break-before)
-  - [`css.properties.break-inside`](https://developer.mozilla.org/docs/Web/CSS/break-inside)
+  - [`api.ByteLengthQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/ByteLengthQueuingStrategy) +1 +1 +1
+  - [`api.CountQueuingStrategy`](https://developer.mozilla.org/docs/Web/API/CountQueuingStrategy) +1 +1 +1
+  - [`api.HTMLMarqueeElement`](https://developer.mozilla.org/docs/Web/API/HTMLMarqueeElement) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream) +1 +1 +1
+  - [`api.Response.body`](https://developer.mozilla.org/docs/Web/API/Response/body)
+  - `api.Window.open.once_per_event`
+  - [`css.properties.break-after`](https://developer.mozilla.org/docs/Web/CSS/break-after) +1
+  - `css.properties.break-after.paged_context.page`
+  - [`css.properties.break-before`](https://developer.mozilla.org/docs/Web/CSS/break-before) +1
+  - `css.properties.break-before.paged_context.page`
+  - [`css.properties.break-inside`](https://developer.mozilla.org/docs/Web/CSS/break-inside) +1 +1
   - [`html.elements.marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee)
 
 ## Jan 2019
 ### Browsers released:
   - {'browser':'chrome','version':'72'}
   - {'browser':'firefox','version':'65'}
+### These Features became stable across all major browsers:
+  - [`api.URL.toJSON`](https://developer.mozilla.org/docs/Web/API/URL/toJSON)
+  - [`api.Window.screenLeft`](https://developer.mozilla.org/docs/Web/API/Window/screenLeft)
+  - [`api.Window.screenTop`](https://developer.mozilla.org/docs/Web/API/Window/screenTop)
+  - [`css.at-rules.media.any-hover`](https://developer.mozilla.org/docs/Web/CSS/@media/any-hover)
+  - [`css.at-rules.media.any-pointer`](https://developer.mozilla.org/docs/Web/CSS/@media/any-pointer)
+  - [`css.at-rules.media.hover`](https://developer.mozilla.org/docs/Web/CSS/@media/hover)
+  - [`css.at-rules.media.pointer`](https://developer.mozilla.org/docs/Web/CSS/@media/pointer)
 
 
 
@@ -1136,13 +2578,62 @@
 
 ## Nov 2018
 ### These Features became stable across all major browsers:
-  - [`api.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode)
-  - [`api.SecurityPolicyViolationEvent`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent)
+  - [`api.CSSStyleDeclaration.@@iterator`](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/@@iterator)
+  - `api.DOMTokenList.replace.boolean_value`
+  - [`api.DataTransfer.setDragImage`](https://developer.mozilla.org/docs/Web/API/DataTransfer/setDragImage)
+  - [`api.Element.getAttributeNames`](https://developer.mozilla.org/docs/Web/API/Element/getAttributeNames)
+  - [`api.Element.securitypolicyviolation_event`](https://developer.mozilla.org/docs/Web/API/Element/securitypolicyviolation_event)
+  - [`api.Element.toggleAttribute`](https://developer.mozilla.org/docs/Web/API/Element/toggleAttribute)
+  - [`api.Element.transitionend_event`](https://developer.mozilla.org/docs/Web/API/Element/transitionend_event)
+  - [`api.File.lastModified`](https://developer.mozilla.org/docs/Web/API/File/lastModified)
+  - `api.FormData.@@iterator`
+  - [`api.FormData.delete`](https://developer.mozilla.org/docs/Web/API/FormData/delete)
+  - [`api.FormData.entries`](https://developer.mozilla.org/docs/Web/API/FormData/entries)
+  - `api.FormData.forEach`
+  - [`api.FormData.get`](https://developer.mozilla.org/docs/Web/API/FormData/get)
+  - [`api.FormData.getAll`](https://developer.mozilla.org/docs/Web/API/FormData/getAll)
+  - [`api.FormData.has`](https://developer.mozilla.org/docs/Web/API/FormData/has)
+  - [`api.FormData.keys`](https://developer.mozilla.org/docs/Web/API/FormData/keys)
+  - [`api.FormData.set`](https://developer.mozilla.org/docs/Web/API/FormData/set)
+  - [`api.FormData.values`](https://developer.mozilla.org/docs/Web/API/FormData/values)
+  - [`api.HTMLAnchorElement.relList`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/relList)
+  - [`api.HTMLAreaElement.relList`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/relList)
+  - [`api.HTMLButtonElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/labels)
+  - [`api.HTMLElement.tabIndex`](https://developer.mozilla.org/docs/Web/API/HTMLElement/tabIndex)
+  - [`api.HTMLInputElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/labels)
+  - [`api.HTMLLabelElement.control`](https://developer.mozilla.org/docs/Web/API/HTMLLabelElement/control)
+  - [`api.HTMLMeterElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLMeterElement/labels)
+  - [`api.HTMLObjectElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/reportValidity)
+  - [`api.HTMLOutputElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/labels)
+  - [`api.HTMLProgressElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLProgressElement/labels)
+  - [`api.HTMLSelectElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/labels)
+  - [`api.HTMLTextAreaElement.labels`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/labels)
+  - [`api.MediaDeviceInfo.toJSON`](https://developer.mozilla.org/docs/Web/API/MediaDeviceInfo/toJSON)
+  - [`api.MediaStreamAudioDestinationNode`](https://developer.mozilla.org/docs/Web/API/MediaStreamAudioDestinationNode) +1
+  - [`api.PerformanceResourceTiming.secureConnectionStart`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart)
+  - [`api.PerformanceTiming.secureConnectionStart`](https://developer.mozilla.org/docs/Web/API/PerformanceTiming/secureConnectionStart)
+  - [`api.RTCPeerConnection.getConfiguration`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getConfiguration)
+  - [`api.SecurityPolicyViolationEvent`](https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent) +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.ServiceWorkerRegistration.updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache)
+  - [`api.TextTrack.id`](https://developer.mozilla.org/docs/Web/API/TextTrack/id)
+  - [`api.TextTrackList.change_event`](https://developer.mozilla.org/docs/Web/API/TextTrackList/change_event)
+  - [`api.TextTrackList.getTrackById`](https://developer.mozilla.org/docs/Web/API/TextTrackList/getTrackById)
+  - [`api.TextTrackList.removetrack_event`](https://developer.mozilla.org/docs/Web/API/TextTrackList/removetrack_event)
+  - [`api.WorkerGlobalScope.securitypolicyviolation_event`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event)
   - [`api.origin`](https://developer.mozilla.org/docs/Web/API/origin)
-  - [`css.properties.-webkit-mask-composite`](https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite)
+  - [`css.at-rules.media.-webkit-device-pixel-ratio`](https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio)
+  - [`css.at-rules.media.-webkit-max-device-pixel-ratio`](https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio)
+  - [`css.at-rules.media.-webkit-min-device-pixel-ratio`](https://developer.mozilla.org/docs/Web/CSS/@media/-webkit-device-pixel-ratio)
   - [`css.properties.-webkit-mask-position-x`](https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-x)
   - [`css.properties.-webkit-mask-position-y`](https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-y)
+  - `css.properties.font-stretch.percentage`
+  - `css.properties.mask-image.multiple_mask_images`
+  - `css.properties.mask-image.svg_masks`
   - [`css.properties.overflow-wrap`](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap)
+  - `css.properties.text-transform.uppercase_eszett`
+  - `javascript.builtins.Intl.Collator.Collator.options_caseFirst_parameter`
+  - [`javascript.builtins.Intl.DateTimeFormat.formatToParts`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatToParts)
+  - [`javascript.builtins.Promise.finally`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally)
 
 ## Oct 2018
 ### Browsers released:
@@ -1150,8 +2641,18 @@
   - {'browser':'edge','version':'18'}
   - {'browser':'firefox','version':'63'}
 ### These Features became stable across all major browsers:
-  - [`api.RTCPeerConnectionIceEvent`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceEvent)
+  - `api.CustomEvent.worker_support`
+  - [`api.Event.srcElement`](https://developer.mozilla.org/docs/Web/API/Event/srcElement)
+  - [`api.HTMLIFrameElement.allowFullscreen`](https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/allowFullscreen)
+  - [`api.RTCPeerConnectionIceEvent`](https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceEvent) +1 +1
+  - `api.Request.Request.cross_origin_stripped`
+  - [`css.at-rules.font-face.font-stretch`](https://developer.mozilla.org/docs/Web/CSS/@font-face/font-stretch)
+  - `css.at-rules.font-face.src.format_variations`
+  - `css.properties.column-gap.grid_context`
   - [`css.properties.font-variation-settings`](https://developer.mozilla.org/docs/Web/CSS/font-variation-settings)
+  - `css.properties.gap.grid_context`
+  - `css.properties.row-gap.grid_context`
+  - `html.elements.iframe.allowfullscreen`
 
 ## Sep 2018
 ### Browsers released:
@@ -1161,17 +2662,27 @@
   - {'browser':'safari_ios','version':'12'}
 
 ## Aug 2018
+### These Features became stable across all major browsers:
+  - `css.properties.cursor.grab`
 
 ## Jul 2018
 ### Browsers released:
   - {'browser':'chrome','version':'68'}
+### These Features became stable across all major browsers:
+  - [`api.Request.destination`](https://developer.mozilla.org/docs/Web/API/Request/destination)
+  - `css.properties.font-weight.number`
 
 ## Jun 2018
 ### Browsers released:
   - {'browser':'firefox','version':'61'}
 ### These Features became stable across all major browsers:
-  - [`css.properties.paint-order`](https://developer.mozilla.org/docs/Web/CSS/paint-order)
-  - [`javascript.statements.export`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export)
+  - [`api.Document.body`](https://developer.mozilla.org/docs/Web/API/Document/body)
+  - `api.HTMLScriptElement.noModule`
+  - [`api.Navigator.webdriver`](https://developer.mozilla.org/docs/Web/API/Navigator/webdriver)
+  - `api.PerformanceEntry.worker_support`
+  - `html.elements.script.nomodule`
+  - [`javascript.builtins.Array.values`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values)
+  - [`javascript.statements.export`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export) +1
   - [`javascript.statements.import`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import)
 
 ## May 2018
@@ -1179,27 +2690,122 @@
   - {'browser':'chrome','version':'67'}
   - {'browser':'firefox','version':'60'}
 ### These Features became stable across all major browsers:
-  - [`api.AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal)
-  - [`api.Cache`](https://developer.mozilla.org/docs/Web/API/Cache)
-  - [`api.CacheStorage`](https://developer.mozilla.org/docs/Web/API/CacheStorage)
-  - [`api.Client`](https://developer.mozilla.org/docs/Web/API/Client)
-  - [`api.Clients`](https://developer.mozilla.org/docs/Web/API/Clients)
+  - [`api.AbortSignal`](https://developer.mozilla.org/docs/Web/API/AbortSignal) +1 +1
+  - [`api.Cache`](https://developer.mozilla.org/docs/Web/API/Cache) +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.CacheStorage`](https://developer.mozilla.org/docs/Web/API/CacheStorage) +1 +1 +1 +1 +1 +1
+  - [`api.CharacterData.after`](https://developer.mozilla.org/docs/Web/API/CharacterData/after)
+  - [`api.CharacterData.before`](https://developer.mozilla.org/docs/Web/API/CharacterData/before)
+  - [`api.CharacterData.nextElementSibling`](https://developer.mozilla.org/docs/Web/API/CharacterData/nextElementSibling)
+  - [`api.CharacterData.previousElementSibling`](https://developer.mozilla.org/docs/Web/API/CharacterData/previousElementSibling)
+  - [`api.CharacterData.replaceWith`](https://developer.mozilla.org/docs/Web/API/CharacterData/replaceWith)
+  - [`api.Client`](https://developer.mozilla.org/docs/Web/API/Client) +1 +1 +1 +1 +1
+  - [`api.Clients`](https://developer.mozilla.org/docs/Web/API/Clients) +1 +1 +1
+  - `api.Clients.matchAll.options_includeUncontrolled_parameter` +1
+  - [`api.ClipboardEvent.ClipboardEvent`](https://developer.mozilla.org/docs/Web/API/ClipboardEvent/ClipboardEvent)
+  - [`api.DOMTokenList.remove_duplicates`](https://developer.mozilla.org/docs/Web/API/DOMTokenList#Trimming_of_whitespace_and_removal_of_duplicates)
+  - [`api.DOMTokenList.replace`](https://developer.mozilla.org/docs/Web/API/DOMTokenList/replace)
+  - [`api.DOMTokenList.supports`](https://developer.mozilla.org/docs/Web/API/DOMTokenList/supports)
+  - [`api.DOMTokenList.value`](https://developer.mozilla.org/docs/Web/API/DOMTokenList/value)
+  - [`api.DataTransfer.items`](https://developer.mozilla.org/docs/Web/API/DataTransfer/items)
+  - [`api.DataTransferItem.webkitGetAsEntry`](https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry)
+  - [`api.Document.Document`](https://developer.mozilla.org/docs/Web/API/Document/Document)
+  - [`api.Document.append`](https://developer.mozilla.org/docs/Web/API/Document/append)
+  - [`api.Document.childElementCount`](https://developer.mozilla.org/docs/Web/API/Document/childElementCount)
+  - [`api.Document.contentType`](https://developer.mozilla.org/docs/Web/API/Document/contentType)
+  - [`api.Document.documentURI`](https://developer.mozilla.org/docs/Web/API/Document/documentURI)
+  - [`api.Document.firstElementChild`](https://developer.mozilla.org/docs/Web/API/Document/firstElementChild)
+  - [`api.Document.lastElementChild`](https://developer.mozilla.org/docs/Web/API/Document/lastElementChild)
+  - [`api.Document.prepend`](https://developer.mozilla.org/docs/Web/API/Document/prepend)
+  - [`api.DocumentFragment.DocumentFragment`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/DocumentFragment)
+  - [`api.DocumentFragment.append`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/append)
+  - [`api.DocumentFragment.childElementCount`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/childElementCount)
+  - [`api.DocumentFragment.firstElementChild`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/firstElementChild)
+  - [`api.DocumentFragment.getElementById`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/getElementById)
+  - [`api.DocumentFragment.lastElementChild`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/lastElementChild)
+  - [`api.DocumentFragment.prepend`](https://developer.mozilla.org/docs/Web/API/DocumentFragment/prepend)
+  - [`api.DocumentType.after`](https://developer.mozilla.org/docs/Web/API/DocumentType/after)
+  - [`api.DocumentType.before`](https://developer.mozilla.org/docs/Web/API/DocumentType/before)
+  - [`api.DocumentType.replaceWith`](https://developer.mozilla.org/docs/Web/API/DocumentType/replaceWith)
   - [`api.EXT_blend_minmax`](https://developer.mozilla.org/docs/Web/API/EXT_blend_minmax)
-  - [`api.ExtendableEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent)
-  - [`api.ExtendableMessageEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableMessageEvent)
-  - [`api.FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent)
+  - [`api.Element.after`](https://developer.mozilla.org/docs/Web/API/Element/after)
+  - [`api.Element.append`](https://developer.mozilla.org/docs/Web/API/Element/append)
+  - [`api.Element.before`](https://developer.mozilla.org/docs/Web/API/Element/before)
+  - [`api.Element.insertAdjacentElement`](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentElement)
+  - [`api.Element.insertAdjacentHTML`](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentHTML)
+  - [`api.Element.insertAdjacentText`](https://developer.mozilla.org/docs/Web/API/Element/insertAdjacentText)
+  - [`api.Element.prepend`](https://developer.mozilla.org/docs/Web/API/Element/prepend)
+  - [`api.Element.replaceWith`](https://developer.mozilla.org/docs/Web/API/Element/replaceWith)
+  - [`api.ExtendableEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent) +1 +1
+  - `api.ExtendableEvent.waitUntil.async_waitUntil`
+  - [`api.ExtendableMessageEvent`](https://developer.mozilla.org/docs/Web/API/ExtendableMessageEvent) +1 +1 +1 +1 +1 +1
+  - [`api.FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent) +1 +1 +1 +1
+  - [`api.File.webkitRelativePath`](https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath)
+  - [`api.HTMLAnchorElement.origin`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/origin)
+  - [`api.HTMLAnchorElement.ping`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/ping)
+  - [`api.HTMLAreaElement.origin`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/origin)
+  - [`api.HTMLAreaElement.ping`](https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/ping)
+  - [`api.HTMLButtonElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/reportValidity)
+  - [`api.HTMLFieldSetElement.elements`](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/elements)
+  - [`api.HTMLFieldSetElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/reportValidity)
+  - [`api.HTMLFieldSetElement.type`](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/type)
+  - [`api.HTMLFormElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reportValidity)
+  - [`api.HTMLInputElement.minLength`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/minLength)
+  - [`api.HTMLInputElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLInputElement/reportValidity)
+  - [`api.HTMLLinkElement.as`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/as)
+  - [`api.HTMLLinkElement.crossOrigin`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/crossOrigin)
+  - `api.HTMLLinkElement.integrity`
+  - [`api.HTMLLinkElement.relList`](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/relList)
+  - `api.HTMLMediaElement.play.returns_promise`
+  - `api.HTMLScriptElement.integrity`
+  - [`api.HTMLSelectElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/reportValidity)
+  - `api.HTMLTextAreaElement.minLength`
+  - [`api.HTMLTextAreaElement.reportValidity`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/reportValidity)
+  - [`api.HTMLTextAreaElement.textLength`](https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/textLength)
   - [`api.InstallEvent`](https://developer.mozilla.org/docs/Web/API/InstallEvent)
-  - [`api.OES_vertex_array_object`](https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object)
-  - [`api.ServiceWorker`](https://developer.mozilla.org/docs/Web/API/ServiceWorker)
-  - [`api.ServiceWorkerContainer`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer)
-  - [`api.ServiceWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope)
-  - [`api.ServiceWorkerRegistration`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration)
-  - [`api.URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams)
-  - [`api.WEBGL_lose_context`](https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context)
+  - [`api.MessageEvent.lastEventId`](https://developer.mozilla.org/docs/Web/API/MessageEvent/lastEventId)
+  - [`api.MouseEvent.buttons`](https://developer.mozilla.org/docs/Web/API/MouseEvent/buttons)
+  - [`api.Navigator.sendBeacon`](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon)
+  - [`api.Navigator.serviceWorker`](https://developer.mozilla.org/docs/Web/API/Navigator/serviceWorker)
+  - [`api.NodeIterator.pointerBeforeReferenceNode`](https://developer.mozilla.org/docs/Web/API/NodeIterator/pointerBeforeReferenceNode)
+  - [`api.NodeIterator.referenceNode`](https://developer.mozilla.org/docs/Web/API/NodeIterator/referenceNode)
+  - [`api.OES_vertex_array_object`](https://developer.mozilla.org/docs/Web/API/OES_vertex_array_object) +1 +1 +1 +1
+  - [`api.PerformanceResourceTiming.nextHopProtocol`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/nextHopProtocol)
+  - [`api.Range.comparePoint`](https://developer.mozilla.org/docs/Web/API/Range/comparePoint)
+  - [`api.Range.intersectsNode`](https://developer.mozilla.org/docs/Web/API/Range/intersectsNode)
+  - `api.SVGElement.blur`
+  - [`api.SVGElement.dataset`](https://developer.mozilla.org/docs/Web/API/SVGElement/dataset)
+  - `api.SVGElement.focus`
+  - `api.SVGElement.tabIndex`
+  - [`api.ServiceWorker`](https://developer.mozilla.org/docs/Web/API/ServiceWorker) +1 +1 +1 +1 +1
+  - [`api.ServiceWorkerContainer`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer) +1 +1 +1 +1 +1 +1 +1
+  - [`api.ServiceWorkerGlobalScope`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope) +1 +1 +1 +1 +1 +1 +1
+  - [`api.ServiceWorkerRegistration`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration) +1 +1 +1 +1 +1 +1 +1
+  - [`api.StorageEvent.StorageEvent`](https://developer.mozilla.org/docs/Web/API/StorageEvent/StorageEvent)
+  - [`api.URL.searchParams`](https://developer.mozilla.org/docs/Web/API/URL/searchParams)
+  - [`api.URL.toString`](https://developer.mozilla.org/docs/Web/API/URL/toString)
+  - [`api.URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) +1 +1
+  - `api.URLSearchParams.URLSearchParams.USVString`
+  - `api.URLSearchParams.URLSearchParams.record`
+  - `api.URLSearchParams.URLSearchParams.sequence` +1 +1 +1 +1 +1 +1 +1 +1 +1 +1 +1
+  - [`api.ValidityState.tooShort`](https://developer.mozilla.org/docs/Web/API/ValidityState/tooShort)
+  - [`api.WEBGL_lose_context`](https://developer.mozilla.org/docs/Web/API/WEBGL_lose_context) +1 +1
   - [`api.WebGLVertexArrayObjectOES`](https://developer.mozilla.org/docs/Web/API/WebGLVertexArrayObjectOES)
-  - [`api.WindowClient`](https://developer.mozilla.org/docs/Web/API/WindowClient)
-  - [`api.caches`](https://developer.mozilla.org/docs/Web/API/caches)
-  - [`api.isSecureContext`](https://developer.mozilla.org/docs/Web/API/isSecureContext)
+  - [`api.WindowClient`](https://developer.mozilla.org/docs/Web/API/WindowClient) +1 +1 +1
+  - [`api.WorkerGlobalScope.navigator`](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/navigator)
+  - [`api.caches`](https://developer.mozilla.org/docs/Web/API/caches) +1
+  - `api.fetch.init_signal_parameter`
+  - [`api.isSecureContext`](https://developer.mozilla.org/docs/Web/API/isSecureContext) +1
+  - `css.properties.gap.grid_context.percentage_values`
+  - `css.properties.transform-origin.svg_elements`
+  - `html.elements.a.ping`
+  - `html.elements.area.ping`
+  - [`html.elements.input.minlength`](https://developer.mozilla.org/docs/Web/HTML/Attributes/minlength)
+  - `html.elements.link.as`
+  - `html.elements.link.crossorigin`
+  - [`html.elements.link.integrity`](https://developer.mozilla.org/docs/Web/Security/Subresource_Integrity)
+  - `html.elements.script.integrity`
+  - [`html.elements.textarea.minlength`](https://developer.mozilla.org/docs/Web/HTML/Attributes/minlength)
+  - [`http.headers.Content-Security-Policy.upgrade-insecure-requests`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)
   - [`http.headers.Upgrade-Insecure-Requests`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests)
 
 ## Apr 2018
@@ -1207,6 +2813,13 @@
   - {'browser':'chrome','version':'66'}
   - {'browser':'edge','version':'17'}
   - {'browser':'safari','version':'11.1'}
+### These Features became stable across all major browsers:
+  - [`api.CSSNamespaceRule.namespaceURI`](https://developer.mozilla.org/docs/Web/API/CSSNamespaceRule/namespaceURI)
+  - [`api.CSSNamespaceRule.prefix`](https://developer.mozilla.org/docs/Web/API/CSSNamespaceRule/prefix)
+  - [`api.MediaStreamTrack.mute_event`](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/mute_event)
+  - [`api.MediaStreamTrack.muted`](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/muted)
+  - [`api.MediaStreamTrack.unmute_event`](https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/unmute_event)
+  - `css.properties.position.position_sticky_table_elements`
 
 ## Mar 2018
 ### Browsers released:
@@ -1216,27 +2829,32 @@
 
 ## Feb 2018
 ### These Features became stable across all major browsers:
-  - [`api.RTCRtpSender`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender)
+  - [`api.Document.alinkColor`](https://developer.mozilla.org/docs/Web/API/Document/alinkColor)
+  - [`api.Document.all`](https://developer.mozilla.org/docs/Web/API/Document/all)
+  - [`api.Document.bgColor`](https://developer.mozilla.org/docs/Web/API/Document/bgColor)
+  - [`api.Document.captureEvents`](https://developer.mozilla.org/docs/Web/API/Document/captureEvents)
+  - [`api.Document.clear`](https://developer.mozilla.org/docs/Web/API/Document/clear)
+  - [`api.Document.close`](https://developer.mozilla.org/docs/Web/API/Document/close)
+  - [`api.Document.dir`](https://developer.mozilla.org/docs/Web/API/Document/dir)
+  - [`api.Document.embeds`](https://developer.mozilla.org/docs/Web/API/Document/embeds)
+  - [`api.Document.fgColor`](https://developer.mozilla.org/docs/Web/API/Document/fgColor)
+  - [`api.Document.linkColor`](https://developer.mozilla.org/docs/Web/API/Document/linkColor)
+  - [`api.Document.open`](https://developer.mozilla.org/docs/Web/API/Document/open)
+  - [`api.Document.plugins`](https://developer.mozilla.org/docs/Web/API/Document/plugins)
+  - [`api.Document.releaseEvents`](https://developer.mozilla.org/docs/Web/API/Document/releaseEvents)
+  - [`api.Document.vlinkColor`](https://developer.mozilla.org/docs/Web/API/Document/vlinkColor)
+  - [`api.Document.writeln`](https://developer.mozilla.org/docs/Web/API/Document/writeln)
+  - [`api.PerformanceResourceTiming.workerStart`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/workerStart)
+  - [`api.RTCRtpSender`](https://developer.mozilla.org/docs/Web/API/RTCRtpSender) +1
+  - [`api.Request.cache`](https://developer.mozilla.org/docs/Web/API/Request/cache)
+  - [`http.headers.Content-Security-Policy.frame-ancestors`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
   - [`http.headers.X-Content-Type-Options`](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Content-Type-Options)
 
 ## Jan 2018
 ### Browsers released:
   - {'browser':'chrome','version':'64'}
   - {'browser':'firefox','version':'58'}
+### These Features became stable across all major browsers:
+  - [`javascript.builtins.Proxy.revocable`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable)
+  - `javascript.statements.for_of.async_iterators`
 
-
-{
-  id: 'webextensions.api.tabs.Tab.active',
-  compat: {
-    source_file: 'webextensions/api/tabs.json',
-    support: {
-      chrome: [Object],
-      edge: [Object],
-      firefox: [Object],
-      firefox_android: [Object],
-      opera: [Object],
-      safari: [Object],
-      safari_ios: [Object]
-    }
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@mdn/browser-compat-data@5.3.24":
-  version "5.3.24"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.3.24.tgz#a663e36cbf6a29e737726fa0a227d074eded350a"
-  integrity sha512-0USwV4F7T4vWGqPoefi0j103sq6Nut2YEXqLz9TUyoj7LBbqXSeWseNRHA7C6LXXm0glrvllKXdeju4oHqIxZw==
+"@mdn/browser-compat-data@5.5.14":
+  version "5.5.14"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.5.14.tgz#31d8174c2d153288e97d67cc7c5484ffc49147c0"
+  integrity sha512-K7e35i4XtNWpiOr+aPiy3UccAhFop0HsfVz9RSzlcgaaHb2aD/nN0J3uPPLedyTokMiebxN0gxkL/WXpzNQuKg==
 
-caniuse-db@1.0.30001550:
-  version "1.0.30001550"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001550.tgz#97ed54b325bca6b5e62c9a545bbd7be4b43e9bac"
-  integrity sha512-5hmk/Y7yfsKN1o5Im/6e0lBdxkL39UqIswDe0/PXY4YWVndpQ59h6XCWLHoaVSRxhMJU+BsDuMvKcDNl8JBpKg==
+caniuse-db@1.0.30001594:
+  version "1.0.30001594"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001594.tgz#c87e5956d30b56c270db52f910bb0d12da7a5395"
+  integrity sha512-XARJYymQ8g91GQCGIIBTlQ/8xdtizKKcMtTXbjW8qLfzpimqKUN+CdM2nOVB2q5YyF5GY8L5gthplgJTZa/2gw==


### PR DESCRIPTION
I went looking for WithResolvers but didnt see it here despite it being in the compat json.



Change 1: `getCompatData()` didnt expect sub-features underneath any namespaces that had their own `__compat`. But.. now it does.

That expanded the number of features by A LOT 

Change 2: So I also did a thing to hide subfeatures cuz otherwise you end up with something silly like...
![image](https://github.com/connorjclark/web-features-evergreen/assets/39191/277c4d04-5738-4c4f-af30-c208d2b5ef0f)

Change 3: lastly... i missed not having console.log() in my terminal so i made a dedicated string and fs.writeFile deal.  sry